### PR TITLE
White list docker compose file format 3.7

### DIFF
--- a/templates/dockerhost/check_docker_containers.erb
+++ b/templates/dockerhost/check_docker_containers.erb
@@ -173,7 +173,7 @@ def _collect_compose_service(compose_file, service_name, logger):
     res = []
     with open(compose_file) as fd:
         data = yaml.load(fd)
-        if data.get('version') not in ['2', '2.1', '2.2', '2.3', '2.4', '3']:
+        if data.get('version') not in ['2', '2.1', '2.2', '2.3', '2.4', '3', '3.7']:
             logger.debug('Skipping {!s}, unknown version'.format(compose_file))
             return []
         for service in data.get('services', []):


### PR DESCRIPTION
Our new sunet-jenkins setup uses docker compose file format 3.7, and it
still works as check_docker_containers expects, so white list that
version to.