### PR TITLE
Include ufw in sunet::misc::ufw_allow

### DIFF
--- a/manifests/misc/ufw_allow.pp
+++ b/manifests/misc/ufw_allow.pp
@@ -23,6 +23,7 @@ define sunet::misc::ufw_allow(
       }
       each(flatten([$port])) |$_port| {
         each(flatten([$proto])) |$_proto| {
+          include ufw
           ensure_resource('ufw::allow', "_ufw_allow__from_${_from}__to_${_to}__${_port}/${_proto}", {
             from  => $_from,
             ip    => $_to,


### PR DESCRIPTION
Would it make sense to include ufw from this file? I ran into this when setting up a new machine with only `sunet::dockerhost` which uses `ufw_allow` but does not `include ufw`. Other classes like `sunet::server` which call `ufw_allow` does include ufw explicitly.

Maybe there is a more elegant solution than putting the include statement inside the loop, but it is not a technical problem to have repeated includes, per the docs.