### PR TITLE
Invent

### DIFF
--- a/manifests/invent.pp
+++ b/manifests/invent.pp
@@ -1,0 +1,29 @@
+# SUNET Inventory Service
+class sunet::invent(
+  String  $invent_dir            = '/opt/invent',
+  Integer $invent_retention_days = 30,
+) {
+  $host_os = String($::facts['operatingsystem'], "%d")
+  $awk = $host_os ? {
+    alpine => 'gawk',
+    default => 'awk',
+  }
+  $script_dir = "${invent_dir}/scripts"
+
+  file { $invent_dir:
+    ensure => directory,
+  }
+  -> file { $script_dir:
+    ensure => directory,
+  }
+  -> file { "${script_dir}/invent.sh":
+    content => template('sunet/invent/invent.sh.erb'),
+    mode    => '0700',
+  }
+  -> sunet::scriptherder::cronjob { 'inventory':
+    cmd      => "${script_dir}/invent.sh",
+    job_name => 'gather_inventory',
+    user     => 'root',         
+    minute   =>  '*/10',          
+  }
+}

--- a/templates/invent/invent.sh.erb
+++ b/templates/invent/invent.sh.erb
@@ -25,9 +25,13 @@ case "${host_os}" in
     parse_command='cat -'
 esac
 
+# Gather structured data kernel fact
+kernel_fact="${fact_dir}/kernel.json"
+uname -rvmo | sed -e 's/ #/;#/' -e 's/ \([^ ]\+\) \([^ ]\+\)$/;\1;\2/'| \
+  awk -F ';' '{print "{ \"running-kernel\": { \"kernel-release\": \""$1"\",\"kernel-version\": \""$2"\", \"machine\": \""$3"\", \"operating-system\": \""$4"\" }}"}' | \
+  jq . > ${kernel_fact}
+# Gather structured data package fact
 package_fact="${fact_dir}/packages.json"
-
-# Gather structured data fact
 echo "{
         \"packages\": $(eval ${query_command} | eval ${parse_command} 2> /dev/null | jq -s .)
       }" \
@@ -35,9 +39,8 @@ echo "{
 
 # Only run if we have docker
 if [ $(which docker) ]; then
+  # Gather structured data docker fact
   docker_fact="${fact_dir}/docker_ps.json"
-
-  # Gather structured data fact
   echo "{ 
           \"docker_ps\": $(docker ps --format '{{json . }}' | sed 's/\\"//g' | jq -s .)
        }" \

--- a/templates/invent/invent.sh.erb
+++ b/templates/invent/invent.sh.erb
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+datadir="<%= @invent_dir%>/data"
+retention_days="<%= @invent_retention_days%>"
+filename="${datadir}/data-$(date +%Y%m%dT%H%M%S).json"
+latest="${datadir}/latest.json"
+host_os="<%= @host_os %>"
+fact_dir="/var/lib/puppet/facts.d"
+# Gather packages
+
+case "${host_os}" in
+  alpine)
+    query_command="apk list -q"
+    parse_command="awk '{print \$1}' | sed 's/\-\\([0-9]\\)/ \1/' | awk -v q='\"' '{print \"\{ \"q\$1q\": \"q\$2q\" }\" }' | jq -s ."
+    ;;
+  centos | fedora | redhat)
+    query_command="rpm -qa"
+    ;;
+  debian | ubuntu)
+    query_command="dpkg-query -W"
+    parse_command="awk -v q='\"' '{print \"\{ \"q\$1q\": \"q\$2q\" \}\" }' | jq -s ."
+    ;;
+  *)
+    query_command='echo {\"unknown\": \"none\"}'
+    parse_command='cat -'
+esac
+
+package_fact="${fact_dir}/packages.json"
+
+# Gather structured data fact
+echo "{
+        \"packages\": $(eval ${query_command} | eval ${parse_command} 2> /dev/null | jq -s .)
+      }" \
+    | jq . > ${package_fact}
+
+# Only run if we have docker
+if [ $(which docker) ]; then
+  docker_fact="${fact_dir}/docker_ps.json"
+
+  # Gather structured data fact
+  echo "{ 
+          \"docker_ps\": $(docker ps --format '{{json . }}' | sed 's/\\"//g' | jq -s .)
+       }" \
+    | jq . > ${docker_fact}
+
+fi
+
+# Export facts
+mkdir -p ${datadir}
+puppet facts --render-as json 2>/dev/null | jq . > ${filename}
+rm -f ${latest}
+ln -s ${filename} ${latest}
+
+# Clean out old facts
+find ${datadir} -type f -mtime +${retention_days} -delete 

--- a/templates/invent/invent.sh.erb
+++ b/templates/invent/invent.sh.erb
@@ -51,8 +51,7 @@ fi
 # Export facts
 mkdir -p ${datadir}
 puppet facts --render-as json 2>/dev/null | jq . > ${filename}
-rm -f ${latest}
-ln -s ${filename} ${latest}
+ln -f -s "${filename}" "${latest}"
 
 # Clean out old facts
 find ${datadir} -type f -mtime +${retention_days} -delete 


### PR DESCRIPTION
This class adds an inventory utility that will gather a lot of data and make it available in two ways, using a cron-job and a shell script:

1. It will gather information and store it as structured data facts in json format, about:
  - installed packages
  - running containers using docker ps (if applicable), and
  - information about the running kernel using uname 
2. It will export all known facts from facter/puppet using the puppet facts command in json format and make it available as file in /opt/invent/data. There will be a symlink called latest.json that will point to the latest file, and it will store the older data for a configurable amount of time.

The idea is to use this information in an effort to be able to scan for systems that might be vulnerable to known exploits.

This class should be compatible with most linux distros (excluding arch based), but it needs jq, awk and sed to be installed on the system. As these utilities are commonly installed in other classes and/or available from the base distro they have not been incuded as dependencies, as it causes this class to be unusable.

In the future the information gather by this utility can be imported to a central data repository use any number of techniques, but for now it is stored on disk.