### PR TITLE
Notify nftables after ruleset file is assembled

### DIFF
--- a/manifests/nftables/ufw_allow_compat.pp
+++ b/manifests/nftables/ufw_allow_compat.pp
@@ -11,9 +11,10 @@ define sunet::nftables::ufw_allow_compat(
 
     $rules_fn = "/etc/nftables/conf.d/${ruleset}.nft"
     ensure_resource('concat', $rules_fn, {
-      owner => 'root',
-      group => 'root',
-      mode  => '0400',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0400',
+      notify => Service['nftables'],
     })
 
     $src_v4 = filter(flatten([$from])) | $this | { is_ipaddr($this, 4) }
@@ -36,7 +37,6 @@ define sunet::nftables::ufw_allow_compat(
           target  => $rules_fn,
           order   => '2000',
           content => $rule_v4,
-          notify  => Service['nftables'],
         }
       }
 
@@ -51,7 +51,6 @@ define sunet::nftables::ufw_allow_compat(
           target  => $rules_fn,
           order   => '3000',
           content => $rule_v6,
-          notify  => Service['nftables'],
         }
       }
     }


### PR DESCRIPTION
Before this change we would notify after each fragment file was created but not after the final ruleset file was actually assembled. When installing a new machine this resulted in the machine being unreachable over SSH until a reboot made nft load the file.