### PR TITLE
This patch adds a simple pre-push hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+hooks:
+	cp git-hooks/* .git/hooks/

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cur_branch=$(git branch --show-current)
+new_tagname=$(git tag --contains=$(git rev-parse HEAD))
+if [[ -z ${new_tagname} ]]; then
+  exit 0
+fi
+if [[ ${new_tagname} =~ ${cur_branch} ]]; then 
+  exit 0
+else
+  echo "Your tag: ${new_tagname} does not match the name of the branch: ${cur_branch}."
+  echo "To push anyway run again with the --no-verify option"
+  exit 1
+fi

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,14 +1,19 @@
 #!/bin/bash
 
 cur_branch=$(git branch --show-current)
-new_tagname=$(git tag --contains=$(git rev-parse HEAD))
+new_tagname=$(git tag --contains="$(git rev-parse HEAD)")
+
+# It is ok if the new tagname is empty, it means that this is an untagged commit and we just move on
 if [[ -z ${new_tagname} ]]; then
-  exit 0
+	exit 0
 fi
-if [[ ${new_tagname} =~ ${cur_branch} ]]; then 
-  exit 0
-else
-  echo "Your tag: ${new_tagname} does not match the name of the branch: ${cur_branch}."
-  echo "To push anyway run again with the --no-verify option"
-  exit 1
+
+# It is also ok if the new tagname matches the name of the branch
+if [[ ${new_tagname} =~ ${cur_branch} ]]; then
+	exit 0
 fi
+
+# All other cases means that the new tagname is set, but does not match the name of the branch so we reject it
+echo "Your tag: ${new_tagname} does not match the name of the branch: ${cur_branch}."
+echo "To push anyway run again with the --no-verify option"
+exit 1


### PR DESCRIPTION
The hook will verify that the last tag matches the name of the branch you are in. The reason for this is that we are moving to a new development and release model for puppet-sunet where development is done in the master branch and production machines must use a different tag and branch than the development branch. The normal sunet-2* tag will be used in a branch that will be called sunet-classic.

To install this hook in your local repository you need to run

  make hooks

in the root of this repository.

It is possible to bypass this hook with the --no-verify option.

If you last commit is not tagged, it will simply let the push through.