### PR TITLE
Install correct KVM package on 22.04

### DIFF
--- a/manifests/cloudimage.pp
+++ b/manifests/cloudimage.pp
@@ -38,7 +38,9 @@ define sunet::cloudimage (
   String           $apt_mirror  = 'http://se.archive.ubuntu.com/ubuntu',
 )
 {
-  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
+  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '22.04') >= 0 {
+    $kvm_package = 'qemu-system-x86'
+  } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     $kvm_package = 'qemu-kvm'
   } else {
     $kvm_package = 'kvm'  # old name


### PR DESCRIPTION
Before this fix puppet will always return a package change:
```
Notice: /Stage[main]/Cnaas::Kvmhost/Cnaas::Cloudimage[example.cnaas.sunet.se]/Sunet::Cloudimage[example.cnaas.sunet.se]/Package[qemu-kvm]/ensure: created
```

This is because the package has another name now:
```
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'qemu-system-x86' instead of 'qemu-kvm'
qemu-system-x86 is already the newest version (1:6.2+dfsg-2ubuntu6.6).
0 upgraded, 0 newly installed, 0 to remove and 6 not upgraded.
```

So now we directly go for qemu-system-x86 instead.