### PR TITLE
add support for iif parameter for docker_expose.nft 

### DIFF
--- a/manifests/nftables/docker_expose.pp
+++ b/manifests/nftables/docker_expose.pp
@@ -5,6 +5,7 @@ define sunet::nftables::docker_expose(
   Enum['tcp', 'udp'] $proto = 'tcp',
   String $docker_v4 = '172.16.0.2',
   String $docker_v6 = 'fd00::2',
+  String $iif = 'eth0',
 ) {
   $safe_name = regsubst($title, '[^0-9A-Za-z_]', '_', 'G')
 

--- a/templates/nftables/600-docker_expose.nft.erb
+++ b/templates/nftables/600-docker_expose.nft.erb
@@ -2,10 +2,10 @@
 # DNAT packets to an exposed service running in a Docker container
 #
 <% if @saddr_v4.is_a? String -%>
-add rule ip nat prerouting iif eth0 <%= @proto -%> <%= @dport %> dnat to 172.16.0.2 comment "docker_expose <%= @name %>"
+add rule ip nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to 172.16.0.2 comment "docker_expose <%= @name %>"
 <% end -%>
 <% if @saddr_v6.is_a? String -%>
-add rule ip6 nat prerouting iif eth0 <%= @proto -%> <%= @dport %> dnat to fd00::2 comment "docker_expose <%= @name %>"
+add rule ip6 nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to fd00::2 comment "docker_expose <%= @name %>"
 <% end -%>
 
 #


### PR DESCRIPTION
add support for iif parameter for docker_expose.nft so you can change the interface you want to publish services on, in safespring you might need to publish on wireguard overlay tunnel interface for example