### PR TITLE
Make docker containers able to reach outside via any interface, not just via eth0

### DIFF
--- a/templates/dockerhost/200-dockerhost_nftables.nft.erb
+++ b/templates/dockerhost/200-dockerhost_nftables.nft.erb
@@ -18,18 +18,18 @@ table ip6 nat {
 #
 # SNAT packages _from_ Docker. Can't use iifname in postrouting rules.
 #
-add rule ip nat postrouting ip saddr { 172.16.0.0/12 } oif eth0 counter masquerade comment "SNAT traffic from Docker"
-add rule ip6 nat postrouting ip6 saddr { fd00::2/128 } oif eth0 counter masquerade comment "SNAT traffic from Docker"
-add rule ip6 nat postrouting ip6 saddr { fd0c::/16 } oif eth0 counter masquerade comment "SNAT traffic from Docker"
+add rule ip nat postrouting ip saddr { 172.16.0.0/12 } iif to_docker counter masquerade comment "SNAT traffic from Docker"
+add rule ip6 nat postrouting ip6 saddr { fd00::2/128 } iif to_docker counter masquerade comment "SNAT traffic from Docker"
+add rule ip6 nat postrouting ip6 saddr { fd0c::/16 } iif to_docker counter masquerade comment "SNAT traffic from Docker"
 
 #
-# Allow forwarding packages from docker to eth0
+# Allow forwarding packages from docker
 #
 add rule inet filter forward ct state established counter accept
-add rule inet filter forward iifname to_docker oif eth0 counter accept comment "Forward traffic from Docker"
+add rule inet filter forward iifname to_docker counter accept comment "Forward traffic from Docker"
 
 #
-# Allow ICMP from eth0 to Docker. Necessary for path-mtu at least.
+# Allow ICMP to Docker. Necessary for path-mtu at least.
 #
-add rule inet filter forward iif eth0 oifname to_docker ip protocol icmp counter accept comment "Allow ICMP to Docker"
-add rule inet filter forward iif eth0 oifname to_docker ip6 nexthdr icmpv6 counter accept comment "Allow ICMP to Docker"
+add rule inet filter forward oifname to_docker ip protocol icmp counter accept comment "Allow ICMP to Docker"
+add rule inet filter forward oifname to_docker ip6 nexthdr icmpv6 counter accept comment "Allow ICMP to Docker"


### PR DESCRIPTION


When having multiple interafces on the host like eth0 and wg0 this will allow containers to reach things behind any of those interfaces by omitting eth0 in rules and just filter on to_docker interface instead.

Tested on a host with eth0 and wg0, conntrack states are added correctly both for outgoing traffic via eth0 and wg0. Traffic to docker host is not affected and still sees to_docker ip addresses only.