### PR TITLE
avoid starting services and setting up firewall rules before docker-in-namespace is ready

### DIFF
--- a/manifests/docker_compose.pp
+++ b/manifests/docker_compose.pp
@@ -1,5 +1,5 @@
 # Wrapper for garethr-docker docker_compose to do SUNET specific things
-define sunet::docker_compose(
+define sunet::docker_compose (
   String           $content,
   String           $compose_dir,
   String           $description,
@@ -12,23 +12,36 @@ define sunet::docker_compose(
   String           $owner = 'root',
   Optional[String] $start_command = undef,
 ) {
-  $compose_file = "${compose_dir}/${service_name}/${compose_filename}"
+  if $::facts['sunet_nftables_enabled'] == 'yes' {
+    if ! has_key($::facts['networking']['interfaces'], 'to_docker') {
+      notice("sunet::docker_compose: No to_docker interface found, not installing ${service_name}")
+      $_install_service = false
+    } else {
+      $_install_service = true
+    }
+  } else {
+    $_install_service = true
+  }
 
-  # docker-compose uses dirname as project name, so we add $service_name and put the compose_file in there
-  ensure_resource('sunet::misc::create_dir', ["${compose_dir}/${service_name}"], { owner => $owner, group => $group, mode => $mode })
+  if $_install_service {
+    $compose_file = "${compose_dir}/${service_name}/${compose_filename}"
 
-  ensure_resource('file', $compose_file, {
-      ensure  => 'file',
-      mode    => '600',
-      content => $content,
-      require => Class['sunet::dockerhost'],
-  })
+    # docker-compose uses dirname as project name, so we add $service_name and put the compose_file in there
+    ensure_resource('sunet::misc::create_dir', ["${compose_dir}/${service_name}"], { owner => $owner, group => $group, mode => $mode })
 
-  sunet::docker_compose_service { "${service_prefix}-${service_name}":
-    compose_file   => $compose_file,
-    description    => $description,
-    require        => File[$compose_file],
-    service_extras => $service_extras,
-    start_command  => $start_command,
+    ensure_resource('file', $compose_file, {
+        ensure  => 'file',
+        mode    => '600',
+        content => $content,
+        require => Class['sunet::dockerhost'],
+    })
+
+    sunet::docker_compose_service { "${service_prefix}-${service_name}":
+      compose_file   => $compose_file,
+      description    => $description,
+      require        => File[$compose_file],
+      service_extras => $service_extras,
+      start_command  => $start_command,
+    }
   }
 }

--- a/manifests/docker_run.pp
+++ b/manifests/docker_run.pp
@@ -24,64 +24,77 @@ define sunet::docker_run(
   Boolean $uid_gid_consistency = true,
   Boolean $fetch_docker_image  = true,
 ) {
-  if $use_unbound {
-    warning('docker-unbound is deprecated, container name resolution should continue to work using docker network with DNS')
-  }
-
-  if $uid_gid_consistency {
-    $_uid_gid = [
-      '/etc/passwd:/etc/passwd:ro',  # uid consistency
-      '/etc/group:/etc/group:ro',    # gid consistency
-    ]
-  } else { $_uid_gid = [] }
-
-  # Use start_on for docker::run $depends, unless the new argument 'depends' is given
-  $_depends = $depends ? {
-    []      => any2array($start_on),
-    default => flatten([$depends]),
-  }
-
-  # If a non-default network is used, make sure it is created before this container starts
-  $req = $net ? {
-    'host'   => [],
-    'bridge' => [],
-    default  => [Docker_network[$net]],
-  }
-
-  $image_tag = "${image}:${imagetag}"
-  if $fetch_docker_image {
-    docker::image { "${name}_${image_tag}" :  # make it possible to use the same docker image more than once on a node
-      ensure  => $ensure,
-      image   => $image_tag,
-      require => Class['sunet::dockerhost'],
+  if $::facts['sunet_nftables_enabled'] == 'yes' {
+    if ! has_key($::facts['networking']['interfaces'], 'to_docker') {
+      notice("sunet::docker_compose: No to_docker interface found, not installing ${name}")
+      $_install_service = false
+    } else {
+      $_install_service = true
     }
+  } else {
+    $_install_service = true
   }
 
-  docker::run { $name :
-    ensure                   => $ensure,
-    volumes                  => flatten([$volumes, $_uid_gid]),
-    hostname                 => $hostname,
-    ports                    => $ports,
-    expose                   => $expose,
-    env                      => $env,
-    net                      => $net,
-    command                  => $command,
-    dns                      => $dns,
-    depends                  => $_depends,
-    require                  => flatten([$req]),
-    before_start             => $before_start,
-    before_stop              => $before_stop,
-    after_start              => $after_start,
-    after_stop               => $after_stop,
-    docker_service           => true,  # the service 'docker' is maintainer by puppet, so depend on it
-    image                    => $image_tag,
-    extra_parameters         => flatten([$extra_parameters]),
-    extra_systemd_parameters => $extra_systemd_parameters,
-  }
+  if $_install_service {
+    if $use_unbound {
+      warning('docker-unbound is deprecated, container name resolution should continue to work using docker network with DNS')
+    }
 
-  # Remove the upstart file created by earlier versions of garethr-docker
-  exec { "remove_docker_upstart_job_${name}":
-    command => "/bin/rm /etc/init/docker-${name}.conf",
-    onlyif  => "/usr/bin/test -f /etc/init/docker-${name}.conf",
+    if $uid_gid_consistency {
+      $_uid_gid = [
+        '/etc/passwd:/etc/passwd:ro',  # uid consistency
+        '/etc/group:/etc/group:ro',    # gid consistency
+      ]
+    } else { $_uid_gid = [] }
+
+    # Use start_on for docker::run $depends, unless the new argument 'depends' is given
+    $_depends = $depends ? {
+      []      => any2array($start_on),
+      default => flatten([$depends]),
+    }
+
+    # If a non-default network is used, make sure it is created before this container starts
+    $req = $net ? {
+      'host'   => [],
+      'bridge' => [],
+      default  => [Docker_network[$net]],
+    }
+
+    $image_tag = "${image}:${imagetag}"
+    if $fetch_docker_image {
+      docker::image { "${name}_${image_tag}" :  # make it possible to use the same docker image more than once on a node
+        ensure  => $ensure,
+        image   => $image_tag,
+        require => Class['sunet::dockerhost'],
+      }
+    }
+
+    docker::run { $name :
+      ensure                   => $ensure,
+      volumes                  => flatten([$volumes, $_uid_gid]),
+      hostname                 => $hostname,
+      ports                    => $ports,
+      expose                   => $expose,
+      env                      => $env,
+      net                      => $net,
+      command                  => $command,
+      dns                      => $dns,
+      depends                  => $_depends,
+      require                  => flatten([$req]),
+      before_start             => $before_start,
+      before_stop              => $before_stop,
+      after_start              => $after_start,
+      after_stop               => $after_stop,
+      docker_service           => true,  # the service 'docker' is maintainer by puppet, so depend on it
+      image                    => $image_tag,
+      extra_parameters         => flatten([$extra_parameters]),
+      extra_systemd_parameters => $extra_systemd_parameters,
+    }
+
+    # Remove the upstart file created by earlier versions of garethr-docker
+    exec { "remove_docker_upstart_job_${name}":
+      command => "/bin/rm /etc/init/docker-${name}.conf",
+      onlyif  => "/usr/bin/test -f /etc/init/docker-${name}.conf",
+    }
   }
 }

--- a/manifests/dockerhost.pp
+++ b/manifests/dockerhost.pp
@@ -21,6 +21,40 @@ class sunet::dockerhost(
   include sunet::packages::python3_yaml # check_docker_containers requirement
   include stdlib
 
+  if $::facts['sunet_nftables_enabled'] == 'yes' {
+    # Hackishly create the /etc/systemd/system/docker.service.d/ directory before the docker service is installed.
+    # If we do this using 'file', the docker class will fail because of a duplicate declaration.
+    exec { "create_${name}_service_dir":
+      command => '/bin/mkdir -p /etc/systemd/system/docker.service.d/',
+      unless  => '/usr/bin/test -d /etc/systemd/system/docker.service.d/',
+    }
+    # The nftables ns dropin file must be in place bedore the docker service is installed on a new host,
+    # otherwise the docker0 interface will be created and interfere until reboot.
+    #
+    file {
+      '/etc/systemd/system/docker.service.d/docker_nftables_ns.conf':
+        ensure  => file,
+        mode    => '0444',
+        content => template('sunet/dockerhost/systemd_dropin_nftables_ns.conf.erb'),
+        ;
+    }
+
+    if ! has_key($::facts['networking']['interfaces'], 'to_docker') {
+      # Have to check if the Docker service has been (re-)started yet with the nftables ns dropin file in place.
+      # If not, there won't be a to_docker interface, and we can't set up the firewall rules.
+      notice('No to_docker interface found, not setting up the firewall rules for Docker (will probably work next time)')
+    } else {
+      file {
+        '/etc/nftables/conf.d/200-sunet_dockerhost.nft':
+          ensure  => file,
+          mode    => '0400',
+          content => template('sunet/dockerhost/200-dockerhost_nftables.nft.erb'),
+          notify  => Service['nftables'],
+          ;
+      }
+    }
+  }
+
   if versioncmp($::operatingsystemrelease, '22.04') <= 0 or $::operatingsystem == 'Debian' {
     # Remove old versions, if installed
     package { ['lxc-docker-1.6.2', 'lxc-docker'] :
@@ -330,21 +364,6 @@ class sunet::dockerhost(
         content => template('sunet/dockerhost/unbound.conf.erb'),
         require => Package['unbound'],
         notify  => Service['unbound'],
-        ;
-    }
-  }
-
-  if $::facts['sunet_nftables_enabled'] == 'yes' {
-    file {
-      '/etc/nftables/conf.d/200-sunet_dockerhost.nft':
-        ensure  => file,
-        mode    => '0400',
-        content => template('sunet/dockerhost/200-dockerhost_nftables.nft.erb'),
-        ;
-      '/etc/systemd/system/docker.service.d/docker_nftables_ns.conf':
-        ensure  => file,
-        mode    => '0444',
-        content => template('sunet/dockerhost/systemd_dropin_nftables_ns.conf.erb'),
         ;
     }
   }

--- a/manifests/nftables/docker_expose.pp
+++ b/manifests/nftables/docker_expose.pp
@@ -27,12 +27,16 @@ define sunet::nftables::docker_expose (
   $dport = sunet::format_nft_set('dport', $port)
   $v6_dnat_dport = sunet::format_nft_set('dport', $dnat_v6_port)
 
-  file {
-    "/etc/nftables/conf.d/600-docker_expose-${safe_name}.nft":
-      ensure  => file,
-      mode    => '0400',
-      content => template('sunet/nftables/600-docker_expose.nft.erb'),
-      notify  => Service['nftables'],
-      ;
+  if ! has_key($::facts['networking']['interfaces'], 'to_docker') {
+    notice('No to_docker interface found, not setting up the DNAT rules for Docker (will probably work next time)')
+  } else {
+    file {
+      "/etc/nftables/conf.d/600-docker_expose-${safe_name}.nft":
+        ensure  => file,
+        mode    => '0400',
+        content => template('sunet/nftables/600-docker_expose.nft.erb'),
+        notify  => Service['nftables'],
+        ;
+    }
   }
 }


### PR DESCRIPTION


- We need to set up the /etc/systemd/system/docker.service.d/ docker_nftables_ns.conf file before the first start of Docker on a new
  host, to not require a reboot before Docker actually works with the
  new to_docker interface (the old docker0 interface interferes).

- We can't add firewall rules referencing the interface "to_docker" before it actually exists (since that will make nftables not load the rules at all).