### PR TITLE
Don't throw away v6 route when IP forwarding

### DIFF
--- a/templates/dockerhost/systemd_dropin_nftables_ns.conf.erb
+++ b/templates/dockerhost/systemd_dropin_nftables_ns.conf.erb
@@ -41,6 +41,16 @@ ExecStartPre=-/bin/echo "--- Routes"
 ExecStartPre=-/sbin/ip route list
 ExecStartPre=-/sbin/ip -6 route list
 
+<% if @facts['dmi']['product']['name'] == 'OpenStack Compute' -%>
+# In environments where we relay on RAs for IPv6 (e.g Safespring) we need to
+# forcely allow RAs even if IP forwarding is enabled (below).
+#
+# We can't use 'all' when configuring "accept_ra" so specify the primary
+# interface.
+# https://unix.stackexchange.com/questions/90443/what-is-the-difference-between-all-default-and-eth-in-proc-sys-net-ipv
+ExecStartPre=/usr/bin/nsenter -t 1 -n -- /sbin/sysctl -w net.ipv6.conf.<%= @facts['networking']['primary'] %>.accept_ra=2
+<%- end -%>
+
 # Docker enables IP forwarding itself, but only in it's namespace of course. We need to enable it
 # in the hosts namespace too.
 ExecStartPre=/usr/bin/nsenter -t 1 -n -- /sbin/sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1

--- a/templates/dockerhost/systemd_dropin_nftables_ns.conf.erb
+++ b/templates/dockerhost/systemd_dropin_nftables_ns.conf.erb
@@ -42,7 +42,7 @@ ExecStartPre=-/sbin/ip route list
 ExecStartPre=-/sbin/ip -6 route list
 
 <% if @facts['dmi']['product']['name'] == 'OpenStack Compute' -%>
-# In environments where we relay on RAs for IPv6 (e.g Safespring) we need to
+# In environments where we rely on RAs for IPv6 (e.g Safespring) we need to
 # forcely allow RAs even if IP forwarding is enabled (below). Otherwise the
 # default IPv6 route will be thrown away.
 #

--- a/templates/dockerhost/systemd_dropin_nftables_ns.conf.erb
+++ b/templates/dockerhost/systemd_dropin_nftables_ns.conf.erb
@@ -43,7 +43,8 @@ ExecStartPre=-/sbin/ip -6 route list
 
 <% if @facts['dmi']['product']['name'] == 'OpenStack Compute' -%>
 # In environments where we relay on RAs for IPv6 (e.g Safespring) we need to
-# forcely allow RAs even if IP forwarding is enabled (below).
+# forcely allow RAs even if IP forwarding is enabled (below). Otherwise the
+# default IPv6 route will be thrown away.
 #
 # We can't use 'all' when configuring "accept_ra" so specify the primary
 # interface.


### PR DESCRIPTION
In environments where we relay on RAs for IPv6 (e.g Safespring) we need to forcely allow RAs even if IP forwarding is enabled.

We can't use 'all' when configuring "accept_ra" so specify the primary interface.
https://unix.stackexchange.com/questions/90443/what-is-the-difference-between-all-default-and-eth-in-proc-sys-net-ipv