### PR TITLE
sunet::noc: Add a class for a noc user that can run specified tasks as root

### DIFF
--- a/files/nftables/999-log.nft
+++ b/files/nftables/999-log.nft
@@ -3,9 +3,7 @@
 # so we keep them but drop other things of little interest so we don't spam the logs generated below otherwise.
 #
 add rule inet filter input pkttype broadcast counter drop comment "Silently drop broadcast"
-add rule ip filter input pkttype multicast counter drop comment "Silently drop multicast"
 add rule inet filter forward pkttype broadcast counter drop comment "Silently drop broadcast"
-add rule ip filter forward pkttype multicast counter drop comment "Silently drop multicast"
 #
 # Log packets being dropped, with rate limiting to avoid the logging itself becoming a problem (attack vector).
 #

--- a/files/nftables/999-log.nft
+++ b/files/nftables/999-log.nft
@@ -3,7 +3,9 @@
 # so we keep them but drop other things of little interest so we don't spam the logs generated below otherwise.
 #
 add rule inet filter input pkttype broadcast counter drop comment "Silently drop broadcast"
+add rule ip filter input pkttype multicast counter drop comment "Silently drop multicast"
 add rule inet filter forward pkttype broadcast counter drop comment "Silently drop broadcast"
+add rule ip filter forward pkttype multicast counter drop comment "Silently drop multicast"
 #
 # Log packets being dropped, with rate limiting to avoid the logging itself becoming a problem (attack vector).
 #

--- a/manifests/misc/system_user.pp
+++ b/manifests/misc/system_user.pp
@@ -4,6 +4,7 @@ define sunet::misc::system_user(
   Boolean                 $system = true,
   Boolean                 $managehome = false,
   String                  $shell = '/bin/false',
+  String                  $ensure = 'present',
   Optional[String]        $home = undef,
   Optional[Integer]       $uid = undef,
   Optional[Integer]       $gid = undef,
@@ -16,13 +17,13 @@ define sunet::misc::system_user(
   }
 
   ensure_resource('group', $group, {
-    ensure => present,
+    ensure => $ensure,
     name   => $group,
     gid    => $gid,
   })
 
   ensure_resource('user', $name, {
-    ensure     => 'present',
+    ensure     => $ensure,
     name       => $_username,
     membership => 'minimum',
     system     => $system,

--- a/manifests/misc/system_user.pp
+++ b/manifests/misc/system_user.pp
@@ -1,14 +1,14 @@
 define sunet::misc::system_user(
-  String                  $group,
-  Optional[String]        $username = undef,
-  Boolean                 $system = true,
-  Boolean                 $managehome = false,
-  String                  $shell = '/bin/false',
-  String                  $ensure = 'present',
-  Optional[String]        $home = undef,
-  Optional[Integer]       $uid = undef,
-  Optional[Integer]       $gid = undef,
-  Optional[Array[String]] $groups = undef,
+  String                    $group,
+  Optional[String]          $username = undef,
+  Boolean                   $system = true,
+  Boolean                   $managehome = false,
+  String                    $shell = '/bin/false',
+  Enum['present', 'absent'] $ensure = 'present',
+  Optional[String]          $home = undef,
+  Optional[Integer]         $uid = undef,
+  Optional[Integer]         $gid = undef,
+  Optional[Array[String]]   $groups = undef,
 ) {
 
   $_username = $username ? {

--- a/manifests/noc.pp
+++ b/manifests/noc.pp
@@ -1,5 +1,7 @@
 # Class for allowing NOC staff to do specific predefined tasks on servers
-class sunet::noc() {
+class sunet::noc(
+  Boolean $allow_reboot = true,
+) {
   $ssh_authorized_keys = hiera_hash('noc_ssh_authorized_keys', undef)
   # If we have Authorized keys for NOC staff, we create a user, 
   # add ssh keys there and allow them to run select commands
@@ -34,12 +36,14 @@ class sunet::noc() {
       owner   => 'root',
       group   => 'root',
     }
-    file { '/usr/local/bin/sunet_noc_reboot':
-      ensure  => file,
-      content => "#!/bin/bash\n/usr/sbin/reboot\n",
-      mode    => '0750',
-      owner   => 'root',
-      group   => 'root',
+    if $allow_reboot {
+      file { '/usr/local/bin/sunet_noc_reboot':
+        ensure  => file,
+        content => "#!/bin/bash\n/usr/sbin/reboot\n",
+        mode    => '0750',
+        owner   => 'root',
+        group   => 'root',
+      }
     }
   }
   # If the keys are not there we will not allow the NOC user to log in and do some clean up
@@ -53,6 +57,11 @@ class sunet::noc() {
     file { '/home/noc/.ssh/authorized_keys':
       ensure  => absent,
     }
+    file { '/usr/local/bin/sunet_noc_reboot':
+      ensure  => absent,
+    }
+  }
+  unless $allow_reboot {
     file { '/usr/local/bin/sunet_noc_reboot':
       ensure  => absent,
     }

--- a/manifests/noc.pp
+++ b/manifests/noc.pp
@@ -1,0 +1,60 @@
+# Class for allowing NOC staff to do specific predefined tasks on servers
+class sunet::noc() {
+  $ssh_authorized_keys = hiera_hash('noc_ssh_authorized_keys', undef)
+  # If we have Authorized keys for NOC staff, we create a user, 
+  # add ssh keys there and allow them to run select commands
+  if is_hash($ssh_authorized_keys) {
+    sunet::misc::system_user { 'noc':
+      username   => 'noc',
+      group      => 'noc',
+      shell      => '/bin/bash',
+      managehome => true
+    }
+    $ssh_authorized_keys.each|$key, $value|{
+      ssh_authorized_key { $key:
+        ensure => $value['ensure'],
+        name   => $value['name'],
+        key    => $value['key'],
+        type   => $value['type'],
+        user   => 'noc'
+      }
+    }
+    # This sudoers rule will allow noc user to run commands without password if they
+    # are in /usr/local/bin and start with sunet_noc_. This is safe because only root 
+    # can put files in /usr/local/bin, however if you have granted a non privileged user
+    # write on /usr/local/bin/ you should NOT use this class (Also, why are you doing that?).
+    #
+    # This means that you (you as in your root user) can drop commands in /usr/local/bin 
+    # from another class, and if they start with sunet_noc_, then the noc user can execute
+    # them as root. 
+    file { '/etc/sudoers.d/99-noc-commands':
+      ensure  => file,
+      content => "noc ALL=(root) NOPASSWD: ^/usr/local/bin/sunet_noc_[a-zA-Z0-9]+$\n",
+      mode    => '0440',
+      owner   => 'root',
+      group   => 'root',
+    }
+    file { '/usr/local/bin/sunet_noc_reboot':
+      ensure  => file,
+      content => "#!/bin/bash\n/usr/sbin/reboot\n",
+      mode    => '0750',
+      owner   => 'root',
+      group   => 'root',
+    }
+  }
+  # If the keys are not there we will not allow the NOC user to log in and do some clean up
+  else {
+    sunet::misc::system_user {'noc':
+      ensure     => absent,
+    }
+    file { '/etc/sudoers.d/99-noc-commands':
+      ensure  => absent,
+    }
+    file { '/home/noc/.ssh/authorized_keys':
+      ensure  => absent,
+    }
+    file { '/usr/local/bin/sunet_noc_reboot':
+      ensure  => absent,
+    }
+  }
+}

--- a/manifests/noc.pp
+++ b/manifests/noc.pp
@@ -2,24 +2,20 @@
 class sunet::noc(
   Boolean $allow_reboot = true,
 ) {
-  $ssh_authorized_keys = hiera_hash('noc_ssh_authorized_keys', undef)
+  $noc_ssh_keys = lookup('noc_ssh_keys')
   # If we have Authorized keys for NOC staff, we create a user, 
   # add ssh keys there and allow them to run select commands
-  if is_hash($ssh_authorized_keys) {
+  if is_hash($noc_ssh_keys) {
     sunet::misc::system_user { 'noc':
       username   => 'noc',
       group      => 'noc',
       shell      => '/bin/bash',
       managehome => true
     }
-    $ssh_authorized_keys.each|$key, $value|{
-      ssh_authorized_key { $key:
-        ensure => $value['ensure'],
-        name   => $value['name'],
-        key    => $value['key'],
-        type   => $value['type'],
-        user   => 'noc'
-      }
+
+    sunet::ssh_keys { 'noc_ssh_keys':
+      config   => { 'noc' => keys($noc_ssh_keys) },
+      database => $noc_ssh_keys,
     }
     # This sudoers rule will allow noc user to run commands without password if they
     # are in /usr/local/bin and start with sunet_noc_. This is safe because only root 


### PR DESCRIPTION
After a meeting with NOC staff we decided that it would be a good idea if NOC staff could ssh as a separate user that could only do predefined tasks, hence this class. The idea is that this class can be easily added to any cosmos ops repo and allow for a standardized way for NOC staff to operate. The workflow is that each project gets onboarded using this class by agreement with, and upon request from, NOC team.

The default is that noc user can reboot the server using sunet_noc_reboot command (can be disabled by setting $allow_reboot parameter to false).

Additional tasks that are allowed to run as root can be added by simply dropping scripts in usr/local/bin/ with the name prefix sunet_noc_

The sudoers rule for this will only allow alpha numeric characters in the rest of the file name and you can not pass in parameters to the file.

That means that you should only create scripts for noc user that run on predefined input and nothing else.

NOC staff is granted access to the noc user by adding the users ssh public key to the noc_ssh_keys hash in hiera:

    noc_ssh_keys:
      kano+0DA0A7A5708FE257:
        key: <public key goes here>
        name: kano@sunet.se
        type: ssh-rsa
    
Justification: This is safe because only the root user is allowed to put things in /usr/local/bin. If you have modified your system to allow a non privileged user to but arbitrary files into /usr/local/bin than that would mean that the noc user could easily be an attack vector for privilege escalation. However, that would only be an issue if the ssh key of a noc user is also compromised, and in that case it is at least no bigger issue, than if that user had been allowed root privileges as would be the case if the noc user did not exist.