### PR TITLE
Disable resolved stub resolver for ubuntu

### DIFF
--- a/manifests/dockerhost.pp
+++ b/manifests/dockerhost.pp
@@ -366,5 +366,9 @@ class sunet::dockerhost(
         notify  => Service['unbound'],
         ;
     }
+  } else {
+    if $::operatingsystem == 'Ubuntu' {
+      ensure_resource('class', 'sunet::disable_resolved_stub', { disable_resolved_stub => true,})
+    }
   }
 }


### PR DESCRIPTION
We need to disable the stub resolver for Ubuntu in docker hosts