### PR TITLE
More Unbound work

### DIFF
--- a/manifests/unbound.pp
+++ b/manifests/unbound.pp
@@ -79,4 +79,10 @@ class sunet::unbound(
     }
     ensure_resource('class', 'sunet::disable_resolved_stub', { disable_resolved_stub => $disable_resolved_stub,})
   }
+  elsif $::operatingsystem == 'Debian' {
+    file_line { 'base':
+        path => '/etc/resolvconf/resolv.conf.d/base',
+        line => "nameserver ${::ipaddress_default}",
+      }
+  }
 }

--- a/manifests/unbound.pp
+++ b/manifests/unbound.pp
@@ -77,6 +77,6 @@ class sunet::unbound(
                     ],
         ;
     }
+    ensure_resource('class', 'sunet::disable_resolved_stub', { disable_resolved_stub => $disable_resolved_stub,})
   }
-  ensure_resource('class', 'sunet::disable_resolved_stub', { disable_resolved_stub => $disable_resolved_stub,})
 }


### PR DESCRIPTION
* Only disable the stub on Ubuntu since Debian doesn't run systemd-resolvd
* Make resolvconf add the external address for unbound to resolv.conf (otherwise docker can't reach unbound in it's namespace)