### PR TITLE
Allow host to access services running in docker

### DIFF
--- a/templates/dockerhost/200-dockerhost_nftables.nft.erb
+++ b/templates/dockerhost/200-dockerhost_nftables.nft.erb
@@ -1,4 +1,7 @@
 table ip nat {
+        chain output {
+		type nat hook output priority -100; policy accept;
+	}
         chain prerouting {
 		type nat hook prerouting priority -100; policy accept;
 	}
@@ -7,6 +10,9 @@ table ip nat {
         }
 }
 table ip6 nat {
+        chain output {
+		type nat hook output priority -100; policy accept;
+	}
         chain prerouting {
 		type nat hook prerouting priority -100; policy accept;
 	}

--- a/templates/nftables/600-docker_expose.nft.erb
+++ b/templates/nftables/600-docker_expose.nft.erb
@@ -3,9 +3,13 @@
 #
 <% if @saddr_v4.is_a? String -%>
 add rule ip nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %>"
+add rule ip nat output oifname lo ip saddr <%= @ipaddress_default -%> ip daddr <%= @ipaddress_default -%> <%= @proto -%> dport <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %> loopback"
+add rule ip nat postrouting oifname <%= @iif %> ip saddr <%= @ipaddress_default -%> ip daddr <%= @dnat_v4_addr %> <%= @proto -%> dport <%= @dport %> comment "docker_expose <%= @name %> loopback"
 <% end -%>
 <% if @saddr_v6.is_a? String -%>
 add rule ip6 nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>]:<%= @dnat_v6_port %> comment "docker_expose <%= @name %> (v6 DNAT)"
+add rule ip6 nat output oifname lo ip6 saddr <%= @ipaddress6_default -%> ip6 daddr <%= @ipaddress6_default %> <%= @proto -%> dport <%= @dport %> dnat to [<%= @dnat_v6_addr %>] comment "docker_expose <%= @name %> (v6 DNAT loopback)"
+add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr [<%= @dnat_v6_addr %>] <%= @proto -%> dport <%= @dport %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
 <% end -%>
 
 #

--- a/templates/nftables/600-docker_expose.nft.erb
+++ b/templates/nftables/600-docker_expose.nft.erb
@@ -9,7 +9,7 @@ add rule ip nat postrouting oifname <%= @iif %> ip saddr <%= @ipaddress_default 
 <% if @saddr_v6.is_a? String -%>
 add rule ip6 nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>]:<%= @dnat_v6_port %> comment "docker_expose <%= @name %> (v6 DNAT)"
 add rule ip6 nat output oifname lo ip6 saddr <%= @ipaddress6_default -%> ip6 daddr <%= @ipaddress6_default %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>] comment "docker_expose <%= @name %> (v6 DNAT loopback)"
-add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr [<%= @dnat_v6_addr %>] <%= @proto -%> <%= @dport %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
+add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr <%= @dnat_v6_addr %> <%= @proto -%> <%= @dport %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
 <% end -%>
 
 #

--- a/templates/nftables/600-docker_expose.nft.erb
+++ b/templates/nftables/600-docker_expose.nft.erb
@@ -3,13 +3,13 @@
 #
 <% if @saddr_v4.is_a? String -%>
 add rule ip nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %>"
-add rule ip nat output oifname lo ip saddr <%= @ipaddress_default -%> ip daddr <%= @ipaddress_default -%> <%= @proto -%> dport <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %> loopback"
-add rule ip nat postrouting oifname <%= @iif %> ip saddr <%= @ipaddress_default -%> ip daddr <%= @dnat_v4_addr %> <%= @proto -%> dport <%= @dport %> comment "docker_expose <%= @name %> loopback"
+add rule ip nat output oifname lo ip saddr <%= @ipaddress_default -%> ip daddr <%= @ipaddress_default -%> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %> loopback"
+add rule ip nat postrouting oifname <%= @iif %> ip saddr <%= @ipaddress_default -%> ip daddr <%= @dnat_v4_addr %> <%= @proto -%> <%= @dport %> comment "docker_expose <%= @name %> loopback"
 <% end -%>
 <% if @saddr_v6.is_a? String -%>
 add rule ip6 nat prerouting iif <%= @iif %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>]:<%= @dnat_v6_port %> comment "docker_expose <%= @name %> (v6 DNAT)"
-add rule ip6 nat output oifname lo ip6 saddr <%= @ipaddress6_default -%> ip6 daddr <%= @ipaddress6_default %> <%= @proto -%> dport <%= @dport %> dnat to [<%= @dnat_v6_addr %>] comment "docker_expose <%= @name %> (v6 DNAT loopback)"
-add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr [<%= @dnat_v6_addr %>] <%= @proto -%> dport <%= @dport %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
+add rule ip6 nat output oifname lo ip6 saddr <%= @ipaddress6_default -%> ip6 daddr <%= @ipaddress6_default %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>] comment "docker_expose <%= @name %> (v6 DNAT loopback)"
+add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr [<%= @dnat_v6_addr %>] <%= @proto -%> <%= @dport %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
 <% end -%>
 
 #


### PR DESCRIPTION
Allow the host to access services running in docker and exposed thought NAT via
the hosts own servicename/hostname (IP of the default NIC).

Inspired by
https://blog.fraggod.net/2017/02/06/nftables-dnat-from-loopback-to-somewhere-else.html