### PR TITLE
Modernize rsyslog

### DIFF
--- a/facts.d/fail2ban_is_enabled.sh
+++ b/facts.d/fail2ban_is_enabled.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if systemctl list-unit-files --state=enabled | grep fail2ban -q; then
+    echo "fail2ban_is_enabled=yes"
+else
+    echo "fail2ban_is_enabled=no"
+fi
+

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -1,4 +1,5 @@
 class sunet::rsyslog(
+  $daily_rotation = false,
   $syslog_servers = hiera_array('syslog_servers',[]),
   $relp_syslog_servers = hiera_array('relp_syslog_servers',[]),
   $syslog_enable_remote = safe_hiera('syslog_enable_remote','true'),
@@ -63,4 +64,12 @@ class sunet::rsyslog(
 
   }
 
+  if ($daily_rotation)
+  {
+     file { '/etc/logrotate.d/rsyslog':
+       ensure  => file,
+       mode    => '644',
+       content => template('sunet/rsyslog/rsyslog.logrotate.erb'),
+     }
+  }
 }

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -1,13 +1,14 @@
 class sunet::rsyslog(
-  $daily_rotation = false,
+  $daily_rotation = true,
   $syslog_servers = hiera_array('syslog_servers',[]),
   $relp_syslog_servers = hiera_array('relp_syslog_servers',[]),
-  $single_log_file = false,
+  $single_log_file = true,
   $syslog_enable_remote = safe_hiera('syslog_enable_remote','true'),
   $udp_port = hiera('udp_port',undef),
   $udp_client = hiera('udp_client',"any"),
   $tcp_port = hiera('tcp_port',undef),
   $tcp_client = hiera('tcp_client',"any"),
+  $traditional_file_format = false,
 ) {
   include stdlib
   ensure_resource('package', 'rsyslog', {

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -98,7 +98,7 @@ class sunet::rsyslog(
      file { '/etc/fail2ban/jail.d/sshd-rsyslog-single-logfile.conf':
        ensure  => file,
        mode    => '644',
-       content => template('rsyslog/fail2ban-ssh-syslog.conf.erb'),
+       content => template('sunet/rsyslog/fail2ban-ssh-syslog.conf.erb'),
        notify  => Service['fail2ban'],
      }
 

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -98,7 +98,7 @@ class sunet::rsyslog(
      file { '/etc/fail2ban/jail.d/sshd-rsyslog-single-logfile.conf':
        ensure  => file,
        mode    => '644',
-       content => template('templates/rsyslog/fail2ban-ssh-syslog.conf.erb'),
+       content => template('rsyslog/fail2ban-ssh-syslog.conf.erb'),
        notify  => Service['fail2ban'],
      }
 

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -60,7 +60,7 @@ class sunet::rsyslog(
   if ($tcp_port or $udp_port) {
 
      if ($udp_port) {
-        ufw::allow { "allow-syslog-udp-${udp_port}": 
+        ufw::allow { "allow-syslog-udp-${udp_port}":
            from  => "${udp_client}",
            ip    => 'any',
            proto => 'udp',

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -2,6 +2,7 @@ class sunet::rsyslog(
   $daily_rotation = false,
   $syslog_servers = hiera_array('syslog_servers',[]),
   $relp_syslog_servers = hiera_array('relp_syslog_servers',[]),
+  $single_log_file = false,
   $syslog_enable_remote = safe_hiera('syslog_enable_remote','true'),
   $udp_port = hiera('udp_port',undef),
   $udp_client = hiera('udp_client',"any"),
@@ -21,10 +22,15 @@ class sunet::rsyslog(
     notify  => Service['rsyslog']
   }
 
+  $default_template = $single_log_file ?
+  {
+      true  => 'rsyslog-default-single-logfile.conf.erb',
+      false => 'rsyslog-default.conf.erb',
+  }
   file { '/etc/rsyslog.d/50-default.conf':
     ensure  => file,
     mode    => '644',
-    content => template('sunet/rsyslog/rsyslog-default.conf.erb'),
+    content => template("sunet/rsyslog/${default_template}"),
     require => Package['rsyslog'],
     notify  => Service['rsyslog']
   }

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -94,4 +94,13 @@ class sunet::rsyslog(
        content => template('sunet/rsyslog/rsyslog.logrotate.erb'),
      }
   }
+  if $single_log_file == true && $facts['fail2ban_is_enabled'] == 'yes' {
+     file { '/etc/fail2ban/jail.d/sshd-rsyslog-single-logfile.conf':
+       ensure  => file,
+       mode    => '644',
+       content => template('templates/rsyslog/fail2ban-ssh-syslog.conf.erb'),
+       notify  => Service['fail2ban'],
+     }
+
+  }
 }

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -94,7 +94,7 @@ class sunet::rsyslog(
        content => template('sunet/rsyslog/rsyslog.logrotate.erb'),
      }
   }
-  if ($single_log_file == true && $facts['fail2ban_is_enabled'] == 'yes') {
+  if ($single_log_file == true and $facts['fail2ban_is_enabled'] == 'yes') {
      file { '/etc/fail2ban/jail.d/sshd-rsyslog-single-logfile.conf':
        ensure  => file,
        mode    => '644',

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -21,6 +21,14 @@ class sunet::rsyslog(
     notify  => Service['rsyslog']
   }
 
+  file { '/etc/rsyslog.d/40-sunet-default.conf':
+    ensure  => file,
+    mode    => '644',
+    content => template('sunet/rsyslog/rsyslog-default.conf.erb'),
+    require => Package['rsyslog'],
+    notify  => Service['rsyslog']
+  }
+
   $do_remote = str2bool($syslog_enable_remote)
 
   file { '/etc/rsyslog.d/60-remote.conf':

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -21,7 +21,7 @@ class sunet::rsyslog(
     notify  => Service['rsyslog']
   }
 
-  file { '/etc/rsyslog.d/40-sunet-default.conf':
+  file { '/etc/rsyslog.d/50-default.conf':
     ensure  => file,
     mode    => '644',
     content => template('sunet/rsyslog/rsyslog-default.conf.erb'),

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -87,7 +87,7 @@ class sunet::rsyslog(
 
   }
 
-  if ($daily_rotation)
+  if ($daily_rotation == true)
   {
      file { '/etc/logrotate.d/rsyslog':
        ensure  => file,

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -13,6 +13,14 @@ class sunet::rsyslog(
     ensure => 'installed'
   })
 
+  file { '/etc/rsyslog.d/rsyslog.conf':
+    ensure  => file,
+    mode    => '644',
+    content => template('sunet/rsyslog/rsyslog.conf.erb'),
+    require => Package['rsyslog'],
+    notify  => Service['rsyslog']
+  }
+
   $do_remote = str2bool($syslog_enable_remote)
 
   file { '/etc/rsyslog.d/60-remote.conf':

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -94,7 +94,7 @@ class sunet::rsyslog(
        content => template('sunet/rsyslog/rsyslog.logrotate.erb'),
      }
   }
-  if $single_log_file == true && $facts['fail2ban_is_enabled'] == 'yes' {
+  if ($single_log_file == true && $facts['fail2ban_is_enabled'] == 'yes') {
      file { '/etc/fail2ban/jail.d/sshd-rsyslog-single-logfile.conf':
        ensure  => file,
        mode    => '644',

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -13,7 +13,7 @@ class sunet::rsyslog(
     ensure => 'installed'
   })
 
-  file { '/etc/rsyslog.d/rsyslog.conf':
+  file { '/etc/rsyslog.conf':
     ensure  => file,
     mode    => '644',
     content => template('sunet/rsyslog/rsyslog.conf.erb'),

--- a/templates/rsyslog/fail2ban-ssh-syslog.conf.erb
+++ b/templates/rsyslog/fail2ban-ssh-syslog.conf.erb
@@ -1,0 +1,4 @@
+[sshd]
+# Rsyslog is configured to log everything to 'syslog'.
+logpath  = /var/log/syslog
+

--- a/templates/rsyslog/rsyslog-default-single-logfile.conf.erb
+++ b/templates/rsyslog/rsyslog-default-single-logfile.conf.erb
@@ -1,0 +1,7 @@
+if $fromhost-ip == "127.0.0.1" then {
+  action(
+    type="omfile"
+    name="omfile-/var/log/syslog"
+    File="/var/log/syslog"
+  )
+}

--- a/templates/rsyslog/rsyslog-default.conf.erb
+++ b/templates/rsyslog/rsyslog-default.conf.erb
@@ -1,0 +1,22 @@
+###############
+#### RULES ####
+###############
+
+#
+# Log anything besides private authentication messages to a single log file
+#
+*.*;auth,authpriv.none		-/var/log/syslog
+
+#
+# Log commonly used facilities to their own log file
+#
+auth,authpriv.*			/var/log/auth.log
+cron.*				-/var/log/cron.log
+kern.*				-/var/log/kern.log
+mail.*				-/var/log/mail.log
+user.*				-/var/log/user.log
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg				:omusrmsg:*

--- a/templates/rsyslog/rsyslog-remote.conf.erb
+++ b/templates/rsyslog/rsyslog-remote.conf.erb
@@ -3,7 +3,12 @@
 
 <% if @do_remote %>
 <% @syslog_servers.each do |server| -%>
-*.*      @<%= server.split(':')[0] %>:<%= server.split(':')[1] %>
+action(
+  type="omfwd"
+  Target="<%= server.split(':')[0] %>"
+  Port="<%= server.split(':')[1] %>"
+  Protocol="udp"
+)
 <% end -%>
 
 <% if @relp_syslog_servers != [] -%>

--- a/templates/rsyslog/rsyslog-remote.conf.erb
+++ b/templates/rsyslog/rsyslog-remote.conf.erb
@@ -7,7 +7,6 @@ action(
   type="omfwd"
   Target="<%= server.split(':')[0] %>"
   Port="<%= server.split(':')[1] %>"
-  Protocol="udp"
 )
 <% end -%>
 

--- a/templates/rsyslog/rsyslog-remote.conf.erb
+++ b/templates/rsyslog/rsyslog-remote.conf.erb
@@ -15,7 +15,11 @@ action(
 module(load="omrelp")
 
 <% @relp_syslog_servers.each do |server| -%>
-*.*      :omrelp:<%= server %>
+action(
+  type="omrelp"
+  target="<%= server.split(':')[0] %>"
+  port="<%= server.split(':')[1] %>"
+)
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/rsyslog/rsyslog-remote.conf.erb
+++ b/templates/rsyslog/rsyslog-remote.conf.erb
@@ -3,7 +3,7 @@
 
 <% if @do_remote %>
 <% @syslog_servers.each do |server| -%>
-*.*      @<%= server.split(':')[0] %>:<%= server.split(':')[1]
+*.*      @<%= server.split(':')[0] %>:<%= server.split(':')[1] %>
 <% end -%>
 
 <% if @relp_syslog_servers != [] -%>

--- a/templates/rsyslog/rsyslog-remote.conf.erb
+++ b/templates/rsyslog/rsyslog-remote.conf.erb
@@ -3,7 +3,7 @@
 
 <% if @do_remote %>
 <% @syslog_servers.each do |server| -%>
-*.*      @<%= server %>
+*.*      @<%= server.split(':')[0] %>:<%= server.split(':')[1]
 <% end -%>
 
 <% if @relp_syslog_servers != [] -%>

--- a/templates/rsyslog/rsyslog.conf.erb
+++ b/templates/rsyslog/rsyslog.conf.erb
@@ -1,0 +1,69 @@
+# /etc/rsyslog.conf configuration file for rsyslog
+#
+# For more information install rsyslog-doc and see
+# /usr/share/doc/rsyslog-doc/html/configuration/index.html
+
+
+#################
+#### MODULES ####
+#################
+
+module(load="imuxsock") # provides support for local system logging
+module(load="imklog")   # provides kernel logging support
+#module(load="immark")  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+#module(load="imudp")
+#input(type="imudp" port="514")
+
+# provides TCP syslog reception
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+
+###############
+#### RULES ####
+###############
+
+#
+# Log anything besides private authentication messages to a single log file
+#
+*.*;auth,authpriv.none		-/var/log/syslog
+
+#
+# Log commonly used facilities to their own log file
+#
+auth,authpriv.*			/var/log/auth.log
+cron.*				-/var/log/cron.log
+kern.*				-/var/log/kern.log
+mail.*				-/var/log/mail.log
+user.*				-/var/log/user.log
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg				:omusrmsg:*

--- a/templates/rsyslog/rsyslog.conf.erb
+++ b/templates/rsyslog/rsyslog.conf.erb
@@ -43,27 +43,3 @@ $WorkDirectory /var/spool/rsyslog
 # Include all config files in /etc/rsyslog.d/
 #
 $IncludeConfig /etc/rsyslog.d/*.conf
-
-
-###############
-#### RULES ####
-###############
-
-#
-# Log anything besides private authentication messages to a single log file
-#
-*.*;auth,authpriv.none		-/var/log/syslog
-
-#
-# Log commonly used facilities to their own log file
-#
-auth,authpriv.*			/var/log/auth.log
-cron.*				-/var/log/cron.log
-kern.*				-/var/log/kern.log
-mail.*				-/var/log/mail.log
-user.*				-/var/log/user.log
-
-#
-# Emergencies are sent to everybody logged in.
-#
-*.emerg				:omusrmsg:*

--- a/templates/rsyslog/rsyslog.conf.erb
+++ b/templates/rsyslog/rsyslog.conf.erb
@@ -20,7 +20,7 @@ module(load="imklog")   # provides kernel logging support
 #module(load="imtcp")
 #input(type="imtcp" port="514")
 
-<% if $traditional_file_format == true -%>
+<% if @traditional_file_format == true -%>
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 <% end -%>
 

--- a/templates/rsyslog/rsyslog.conf.erb
+++ b/templates/rsyslog/rsyslog.conf.erb
@@ -20,6 +20,9 @@ module(load="imklog")   # provides kernel logging support
 #module(load="imtcp")
 #input(type="imtcp" port="514")
 
+<% if $traditional_file_format == true { -%>
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+<% } -%>
 
 ###########################
 #### GLOBAL DIRECTIVES ####

--- a/templates/rsyslog/rsyslog.conf.erb
+++ b/templates/rsyslog/rsyslog.conf.erb
@@ -20,27 +20,24 @@ module(load="imklog")   # provides kernel logging support
 #module(load="imtcp")
 #input(type="imtcp" port="514")
 
+module(load="builtin:omfile"
+  dirCreateMode="0755"
+  fileCreateMode="0640"
+  fileGroup="adm"
+  fileOwner="root"
 <% if @traditional_file_format == true -%>
-$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+  template="RSYSLOG_TraditionalFileFormat"
 <% end -%>
+)
 
 ###########################
 #### GLOBAL DIRECTIVES ####
 ###########################
 
-#
-# Set the default permissions for all log files.
-#
-$FileOwner root
-$FileGroup adm
-$FileCreateMode 0640
-$DirCreateMode 0755
-$Umask 0022
-
-#
-# Where to place spool and state files
-#
-$WorkDirectory /var/spool/rsyslog
+global(
+  # Where to place spool and state files
+  workDirectory="/var/spool/rsyslog"
+)
 
 #
 # Include all config files in /etc/rsyslog.d/

--- a/templates/rsyslog/rsyslog.conf.erb
+++ b/templates/rsyslog/rsyslog.conf.erb
@@ -20,9 +20,9 @@ module(load="imklog")   # provides kernel logging support
 #module(load="imtcp")
 #input(type="imtcp" port="514")
 
-<% if $traditional_file_format == true { -%>
+<% if $traditional_file_format == true -%>
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
-<% } -%>
+<% end -%>
 
 ###########################
 #### GLOBAL DIRECTIVES ####

--- a/templates/rsyslog/rsyslog.logrotate.erb
+++ b/templates/rsyslog/rsyslog.logrotate.erb
@@ -1,0 +1,25 @@
+/var/log/syslog
+/var/log/mail.info
+/var/log/mail.warn
+/var/log/mail.err
+/var/log/mail.log
+/var/log/daemon.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/lpr.log
+/var/log/cron.log
+/var/log/debug
+/var/log/messages
+{
+	rotate 4
+	weekly
+	missingok
+	notifempty
+	compress
+	delaycompress
+	sharedscripts
+	postrotate
+		/usr/lib/rsyslog/rsyslog-rotate
+	endscript
+}

--- a/templates/rsyslog/rsyslog.logrotate.erb
+++ b/templates/rsyslog/rsyslog.logrotate.erb
@@ -12,8 +12,8 @@
 /var/log/debug
 /var/log/messages
 {
-	rotate 4
-	weekly
+	rotate 13
+	daily
 	missingok
 	notifempty
 	compress

--- a/templates/rsyslog/rsyslog.logrotate.erb
+++ b/templates/rsyslog/rsyslog.logrotate.erb
@@ -17,7 +17,6 @@
 	missingok
 	notifempty
 	compress
-	delaycompress
 	sharedscripts
 	postrotate
 		/usr/lib/rsyslog/rsyslog-rotate


### PR DESCRIPTION
This will PR vill change the default behaviour of machines that runs `sunet::rsyslog`. Besides user habits nothing will probably break. Comments? 🍿

### Logrotate daily (configurable)
Rotating logs daily (instead of weekly) will create smaller files that are easier to handle and will probably save some disk space too.

### Syslog to a single file (configurable)
Easier to find relevant log lines when debugging if all logs are collected in the same log file. Use your tools of trade if filtering is needed.

### Modernize configuration syntax
Shines more.

### Modernize log format (configurable)
Use the rsyslogs "new" default log format.
From 
`Apr 14 09:13:01 md-signer-2 rsyslogd: [origin software="rsyslogd" swVersion="8.2102.0" x-pid="743439" x-info="https://www.rsyslog.com"] exiting on signal 15.`
to
`2023-04-14T10:57:05.305806+00:00 md-signer-2 rsyslogd: [origin software="rsyslogd" swVersion="8.2102.0" x-pid="827911" x-info="https://www.rsyslog.com"] exiting on signal 15.`