### PR TITLE
Merge satosa classes from ops repos

### DIFF
--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -65,7 +65,7 @@ class sunet::satosa(
   }
 
   if ($dehydrated_name) {
-    sunet::dehydrated::client { 'enable-dehydrated':
+    class { 'sunet::dehydrated::client':
       domain    => $dehydrated_name,
       ssl_links => true,
     }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -50,6 +50,16 @@ class sunet::satosa(
     }
   }
 
+  $json_config = hiera('satosa_json_config')
+  sort(keys($plugins)).each |$n| {
+    $conf = hiera($n)
+    $fn = $json_config[$n]
+    file { fn:
+      content => inline_template("<%= @conf.to_json %>\n"),
+      notify  => Service['sunet-satosa'],
+    }
+  }
+
   if $::facts['sunet_nftables_enabled'] == 'yes' {
     sunet::nftables::docker_expose { 'allow_https' :
       iif           => $interface,
@@ -91,15 +101,6 @@ class sunet::satosa(
     sunet::snippets::keygen {'satosa_https':
       key_file  => '/etc/satosa/https.key',
       cert_file => '/etc/satosa/https.crt'
-    }
-  }
-
-  if ($enable_oidc) {
-    $client_id     = lookup('client_id')
-    $client_secret = lookup('client_secret')
-    file { '/etc/satosa/cdb.json':
-      ensure  => file,
-      content => template('sunet/satosa/cdb.json.erb')
     }
   }
 

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -1,9 +1,9 @@
 # Class to run Satosa in docker-compose
 class sunet::satosa(
-  $dehydrated_name=undef,
-  $image='docker.sunet.se/satosa',
-  $interface=$::facts['interface_default'],
-  $tag='8.0.1',
+  Optional[String] $dehydrated_name = undef,
+  String           $image           = 'docker.sunet.se/satosa',
+  String           $interface       = $::facts['interface_default'],
+  String           $tag             = '8.0.1',
 ) {
   $proxy_conf = hiera('satosa_proxy_conf')
   $default_conf = {

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -53,7 +53,7 @@ class sunet::satosa(
   $json_configs = lookup('satosa_json_config', undef, undef, {})
   sort(keys($json_configs)).each |$n| {
     $conf = hiera($n)
-    $fn = $json_config[$n]
+    $fn = $json_configs[$n]
     file { fn:
       content => inline_template("<%= @conf.to_json %>\n"),
       notify  => Service['sunet-satosa'],

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -54,7 +54,7 @@ class sunet::satosa(
   sort(keys($json_configs)).each |$n| {
     $conf = hiera($n)
     $fn = $json_configs[$n]
-    file { fn:
+    file { $fn:
       content => inline_template("<%= @conf.to_json %>\n"),
       notify  => Service['sunet-satosa'],
     }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -4,7 +4,7 @@ class sunet::satosa(
   String           $image           = 'docker.sunet.se/satosa',
   String           $interface       = $::facts['interface_default'],
   String           $tag             = '8.0.1',
-  String           $redirect_uri    = lookup('redirect_uri'),
+  Optional[String] $redirect_uri    = lookup('redirect_uri'),
   Boolean          $enable_oidc     = false,
 ) {
   $proxy_conf = hiera('satosa_proxy_conf')

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -64,19 +64,19 @@ class sunet::satosa(
     default => 'present'
   }
 
-  if $::facts['sunet_nftables_enabled'] == 'yes' {
-    sunet::nftables::docker_expose { 'allow_http' :
-      iif           => $interface,
-      allow_clients => 'any',
-      port          => 80,
-    }
-  } else {
-    sunet::misc::ufw_allow { 'allow-http':
-      from => 'any',
-      port => '80'
-    }
-  }
   if ($dehydrated_name) {
+    if $::facts['sunet_nftables_enabled'] == 'yes' {
+      sunet::nftables::docker_expose { 'allow_http' :
+        iif           => $interface,
+        allow_clients => 'any',
+        port          => 80,
+      }
+    } else {
+      sunet::misc::ufw_allow { 'allow-http':
+        from => 'any',
+        port => '80'
+      }
+    }
     file { '/etc/satosa/https.key': ensure => link, target => "/etc/dehydrated/certs/${dehydrated_name}.key" }
     file { '/etc/satosa/https.crt': ensure => link, target => "/etc/dehydrated/certs/${dehydrated_name}/fullchain.pem" }
   } else {

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -31,13 +31,6 @@ class sunet::satosa(
          }
       }
    }
-   sunet::docker_run {'satosa':
-      image    => $image,
-      imagetag => $tag,
-      volumes  => ['/etc/satosa:/etc/satosa','/etc/dehydrated:/etc/dehydrated'],
-      ports    => ['443:8000'],
-      env      => ['METADATA_DIR=/etc/satosa/metadata']
-   }
    file {"/etc/satosa/proxy_conf.yaml":
       content => inline_template("<%= @merged_conf.to_yaml %>\n"),
       notify  => Sunet::Docker_run['satosa']
@@ -96,4 +89,20 @@ class sunet::satosa(
          cert_file => "/etc/satosa/https.crt"
       }
    }
+
+  service {'docker-satosa.service':
+    ensure => 'stopped',
+    enable => false,
+  }
+  service {'docker-alwayshttps.service':
+    ensure => 'stopped',
+    enable => false,
+  }
+  sunet::docker_compose { 'satosa_compose':
+    content          => template('sunet/satosa/docker-compose.yml.erb'),
+    service_name     => 'satosa',
+    compose_dir      => '/opt/',
+    compose_filename => 'docker-compose.yml',
+    description      => 'Satosa',
+  }
 }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -50,7 +50,7 @@ class sunet::satosa(
     }
   }
 
-  $json_configs = lookup('satosa_json_config', undef, undef, [])
+  $json_configs = lookup('satosa_json_config', undef, undef, {})
   sort(keys($json_configs)).each |$n| {
     $conf = hiera($n)
     $fn = $json_config[$n]

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -2,7 +2,7 @@ class sunet::satosa(
   $dehydrated_name=undef,
   $image='docker.sunet.se/satosa',
   $interface = "${::facts['interface_default']}",
-  $tag='3.4-stable'
+  $tag='8.0.1',
 ) {
    $proxy_conf = hiera("satosa_proxy_conf")
    $default_conf = { 

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -61,12 +61,6 @@ class sunet::satosa(
     undef   => 'absent',
     default => 'present'
   }
-  sunet::docker_run {'alwayshttps':
-    ensure => $dehydrated_status
-    image  => 'docker.sunet.se/always-https',
-    ports  => ['80:80'],
-    env    => ['ACME_URL=http://acme-c.sunet.se'],
-  }
 
   if $::facts['sunet_nftables_enabled'] == 'yes' {
     sunet::nftables::docker_expose { 'allow_http' :

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -65,6 +65,11 @@ class sunet::satosa(
   }
 
   if ($dehydrated_name) {
+    sunet::dehydrated::client { 'enable-dehydrated'
+      domain    => $dehydrated_name,
+      ssl_links => true,
+    }
+
     if $::facts['sunet_nftables_enabled'] == 'yes' {
       sunet::nftables::docker_expose { 'allow_http' :
         iif           => $interface,

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -5,7 +5,7 @@ class sunet::satosa(
   $tag='8.0.1',
 ) {
    $proxy_conf = hiera("satosa_proxy_conf")
-   $default_conf = { 
+   $default_conf = {
       "STATE_ENCRYPTION_KEY"       => hiera("satosa_state_encryption_key"),
       "USER_ID_HASH_SALT"          => hiera("satosa_user_id_hash_salt"),
       "CUSTOM_PLUGIN_MODULE_PATHS" => ["plugins"],

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -50,7 +50,7 @@ class sunet::satosa(
     }
   }
 
-  $json_config = hiera('satosa_json_config')
+  $json_config = lookup('satosa_json_config', undef, undef, [])
   sort(keys($plugins)).each |$n| {
     $conf = hiera($n)
     $fn = $json_config[$n]

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -18,7 +18,6 @@ class sunet::satosa(
    ensure_resource('file',"/etc/satosa/run", { ensure => directory } )
    ensure_resource('file',"/etc/satosa/plugins", { ensure => directory } )
    ensure_resource('file',"/etc/satosa/metadata", { ensure => directory } )
-   $key_data = {}
    ["backend","frontend","metadata"].each |$id| {
       if hiera("satosa_${id}_key",undef) != undef {
          sunet::snippets::secret_file { "/etc/satosa/${id}.key": hiera_key => "satosa_${id}_key" }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -55,7 +55,7 @@ class sunet::satosa(
     $conf = lookup($n)
     $fn = $json_configs[$n]
     file { $fn:
-      content => inline_template("<%= @conf.to_json_pretty %>\n"),
+      content => inline_template("<%= @conf.to_json %>\n"),
       notify  => Service['sunet-satosa'],
     }
   }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -4,6 +4,7 @@ class sunet::satosa(
   String           $image           = 'docker.sunet.se/satosa',
   String           $interface       = $::facts['interface_default'],
   String           $tag             = '8.0.1',
+  String           $redirect_uri    = lookup('redirect_uri'),
   Boolean          $enable_oidc     = false,
 ) {
   $proxy_conf = hiera('satosa_proxy_conf')

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -33,7 +33,7 @@ class sunet::satosa(
    }
    file {"/etc/satosa/proxy_conf.yaml":
       content => inline_template("<%= @merged_conf.to_yaml %>\n"),
-      notify  => Sunet::Docker_run['satosa']
+      notify  => Service['sunet-satosa'],
    }
    $plugins = hiera("satosa_config")
    sort(keys($plugins)).each |$n| {
@@ -41,7 +41,7 @@ class sunet::satosa(
       $fn = $plugins[$n]
       file { "$fn":
          content => inline_template("<%= @conf.to_yaml %>\n"),
-         notify  => Sunet::Docker_run['satosa']
+         notify  => Service['sunet-satosa'],
       }
    }
 

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -99,7 +99,7 @@ class sunet::satosa(
     $client_secret = lookup('client_secret')
     file { '/etc/satosa/cdb.json':
       ensure  => file,
-      content => template('mastodon/satosa/cdb.json.erb')
+      content => template('sunet/satosa/cdb.json.erb')
     }
   }
 

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -55,7 +55,7 @@ class sunet::satosa(
     $conf = lookup($n)
     $fn = $json_configs[$n]
     file { $fn:
-      content => inline_template("<%= @conf.to_json %>\n"),
+      content => inline_template("<%= @conf.to_json_pretty %>\n"),
       notify  => Service['sunet-satosa'],
     }
   }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -4,6 +4,7 @@ class sunet::satosa(
   String           $image           = 'docker.sunet.se/satosa',
   String           $interface       = $::facts['interface_default'],
   String           $tag             = '8.0.1',
+  Boolean          $enable_oidc     = false,
 ) {
   $proxy_conf = hiera('satosa_proxy_conf')
   $default_conf = {
@@ -81,6 +82,15 @@ class sunet::satosa(
     sunet::snippets::keygen {'satosa_https':
       key_file  => '/etc/satosa/https.key',
       cert_file => '/etc/satosa/https.crt'
+    }
+  }
+
+  if ($enable_oidc) {
+    $client_id     = lookup('client_id')
+    $client_secret = lookup('client_secret')
+    file { '/etc/satosa/cdb.json':
+      ensure  => file,
+      content => template('mastodon/satosa/cdb.json.erb')
     }
   }
 

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -21,6 +21,9 @@ class sunet::satosa(
   ensure_resource('file','/etc/satosa/run', { ensure => directory } )
   ensure_resource('file','/etc/satosa/plugins', { ensure => directory } )
   ensure_resource('file','/etc/satosa/metadata', { ensure => directory } )
+  ensure_resource('file','/etc/satosa/md-signer2.crt', {
+    content  => file('sunet/md-signer2.crt')
+  })
   ['backend','frontend','metadata'].each |$id| {
     if hiera("satosa_${id}_key",undef) != undef {
       sunet::snippets::secret_file { "/etc/satosa/${id}.key": hiera_key => "satosa_${id}_key" }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -4,7 +4,7 @@ class sunet::satosa(
   String           $image           = 'docker.sunet.se/satosa',
   String           $interface       = $::facts['interface_default'],
   String           $tag             = '8.0.1',
-  Optional[String] $redirect_uri    = lookup('redirect_uri'),
+  Optional[String] $redirect_uri    = lookup('redirect_uri', undef, undef, ''),
   Boolean          $enable_oidc     = false,
 ) {
   $proxy_conf = hiera('satosa_proxy_conf')

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -1,6 +1,8 @@
-require stdlib
-
-class sunet::satosa($dehydrated_name=undef,$image='docker.sunet.se/satosa',$tag='3.4-stable') {
+class sunet::satosa(
+  $dehydrated_name=undef,
+  $image='docker.sunet.se/satosa',
+  $tag='3.4-stable'
+) {
    $proxy_conf = hiera("satosa_proxy_conf")
    $default_conf = { 
       "STATE_ENCRYPTION_KEY"       => hiera("satosa_state_encryption_key"),

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -2,7 +2,7 @@
 class sunet::satosa(
   Optional[String] $dehydrated_name = undef,
   String           $image           = 'docker.sunet.se/satosa',
-  String           $interface       = lookup('interface_default'),
+  String           $interface       = $::facts['interface_default'],
   String           $tag             = '8.0.1',
   Optional[String] $redirect_uri    = lookup('redirect_uri', undef, undef, ''),
   Boolean          $enable_oidc     = false,

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -50,8 +50,8 @@ class sunet::satosa(
     }
   }
 
-  $json_config = lookup('satosa_json_config', undef, undef, [])
-  sort(keys($plugins)).each |$n| {
+  $json_configs = lookup('satosa_json_config', undef, undef, [])
+  sort(keys($json_configs)).each |$n| {
     $conf = hiera($n)
     $fn = $json_config[$n]
     file { fn:

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -65,7 +65,7 @@ class sunet::satosa(
   }
 
   if ($dehydrated_name) {
-    sunet::dehydrated::client { 'enable-dehydrated'
+    sunet::dehydrated::client { 'enable-dehydrated':
       domain    => $dehydrated_name,
       ssl_links => true,
     }

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -1,48 +1,49 @@
+# Class to run Satosa in docker-compose
 class sunet::satosa(
   $dehydrated_name=undef,
   $image='docker.sunet.se/satosa',
-  $interface = "${::facts['interface_default']}",
+  $interface=$::facts['interface_default'],
   $tag='8.0.1',
 ) {
-   $proxy_conf = hiera("satosa_proxy_conf")
-   $default_conf = {
-      "STATE_ENCRYPTION_KEY"       => hiera("satosa_state_encryption_key"),
-      "USER_ID_HASH_SALT"          => hiera("satosa_user_id_hash_salt"),
-      "CUSTOM_PLUGIN_MODULE_PATHS" => ["plugins"],
-      "COOKIE_STATE_NAME"          => "SATOSA_STATE"
-   }
-   $merged_conf = merge($proxy_conf,$default_conf)
-   ensure_resource('file','/etc', { ensure => directory } )
-   ensure_resource('file','/etc/satosa', { ensure => directory } )
-   ensure_resource('file',"/etc/satosa/", { ensure => directory } )
-   ensure_resource('file',"/etc/satosa/run", { ensure => directory } )
-   ensure_resource('file',"/etc/satosa/plugins", { ensure => directory } )
-   ensure_resource('file',"/etc/satosa/metadata", { ensure => directory } )
-   ["backend","frontend","metadata"].each |$id| {
-      if hiera("satosa_${id}_key",undef) != undef {
-         sunet::snippets::secret_file { "/etc/satosa/${id}.key": hiera_key => "satosa_${id}_key" }
-         # assume cert is in cosmos repo
-      } else {
-         # make key pair
-         sunet::snippets::keygen {"satosa_${id}":
-            key_file  => "/etc/satosa/${id}.key",
-            cert_file => "/etc/satosa/${id}.crt"
-         }
+  $proxy_conf = hiera('satosa_proxy_conf')
+  $default_conf = {
+    'STATE_ENCRYPTION_KEY'       => hiera('satosa_state_encryption_key'),
+    'USER_ID_HASH_SALT'          => hiera('satosa_user_id_hash_salt'),
+    'CUSTOM_PLUGIN_MODULE_PATHS' => ['plugins'],
+    'COOKIE_STATE_NAME'          => 'SATOSA_STATE'
+  }
+  $merged_conf = merge($proxy_conf,$default_conf)
+  ensure_resource('file','/etc', { ensure => directory } )
+  ensure_resource('file','/etc/satosa', { ensure => directory } )
+  ensure_resource('file','/etc/satosa/', { ensure => directory } )
+  ensure_resource('file','/etc/satosa/run', { ensure => directory } )
+  ensure_resource('file','/etc/satosa/plugins', { ensure => directory } )
+  ensure_resource('file','/etc/satosa/metadata', { ensure => directory } )
+  ['backend','frontend','metadata'].each |$id| {
+    if hiera("satosa_${id}_key",undef) != undef {
+      sunet::snippets::secret_file { "/etc/satosa/${id}.key": hiera_key => "satosa_${id}_key" }
+      # assume cert is in cosmos repo
+    } else {
+      # make key pair
+      sunet::snippets::keygen {"satosa_${id}":
+        key_file  => "/etc/satosa/${id}.key",
+        cert_file => "/etc/satosa/${id}.crt"
       }
-   }
-   file {"/etc/satosa/proxy_conf.yaml":
-      content => inline_template("<%= @merged_conf.to_yaml %>\n"),
+    }
+  }
+  file {'/etc/satosa/proxy_conf.yaml':
+    content => inline_template("<%= @merged_conf.to_yaml %>\n"),
+    notify  => Service['sunet-satosa'],
+  }
+  $plugins = hiera('satosa_config')
+  sort(keys($plugins)).each |$n| {
+    $conf = hiera($n)
+    $fn = $plugins[$n]
+    file { $fn:
+      content => inline_template("<%= @conf.to_yaml %>\n"),
       notify  => Service['sunet-satosa'],
-   }
-   $plugins = hiera("satosa_config")
-   sort(keys($plugins)).each |$n| {
-      $conf = hiera($n)
-      $fn = $plugins[$n]
-      file { "$fn":
-         content => inline_template("<%= @conf.to_yaml %>\n"),
-         notify  => Service['sunet-satosa'],
-      }
-   }
+    }
+  }
 
   if $::facts['sunet_nftables_enabled'] == 'yes' {
     sunet::nftables::docker_expose { 'allow_https' :
@@ -56,16 +57,16 @@ class sunet::satosa(
       port => '443'
     }
   }
-   $dehydrated_status = $dehydrated_name ? {
-      undef   => 'absent',
-      default => 'present'
-   }
-   sunet::docker_run {'alwayshttps':
-      image    => 'docker.sunet.se/always-https',
-      ports    => ['80:80'],
-      env      => ['ACME_URL=http://acme-c.sunet.se'],
-      ensure   => $dehydrated_status
-   }
+  $dehydrated_status = $dehydrated_name ? {
+    undef   => 'absent',
+    default => 'present'
+  }
+  sunet::docker_run {'alwayshttps':
+    ensure => $dehydrated_status
+    image  => 'docker.sunet.se/always-https',
+    ports  => ['80:80'],
+    env    => ['ACME_URL=http://acme-c.sunet.se'],
+  }
 
   if $::facts['sunet_nftables_enabled'] == 'yes' {
     sunet::nftables::docker_expose { 'allow_http' :
@@ -79,15 +80,15 @@ class sunet::satosa(
       port => '80'
     }
   }
-   if ($dehydrated_name) {
-      file { '/etc/satosa/https.key': ensure => link, target => "/etc/dehydrated/certs/$dehydrated_name.key" }
-      file { '/etc/satosa/https.crt': ensure => link, target => "/etc/dehydrated/certs/${dehydrated_name}/fullchain.pem" }
-   } else {
-      sunet::snippets::keygen {"satosa_https":
-         key_file  => "/etc/satosa/https.key",
-         cert_file => "/etc/satosa/https.crt"
-      }
-   }
+  if ($dehydrated_name) {
+    file { '/etc/satosa/https.key': ensure => link, target => "/etc/dehydrated/certs/${dehydrated_name}.key" }
+    file { '/etc/satosa/https.crt': ensure => link, target => "/etc/dehydrated/certs/${dehydrated_name}/fullchain.pem" }
+  } else {
+    sunet::snippets::keygen {'satosa_https':
+      key_file  => '/etc/satosa/https.key',
+      cert_file => '/etc/satosa/https.crt'
+    }
+  }
 
   service {'docker-satosa.service':
     ensure => 'stopped',

--- a/templates/satosa/cdb.json.erb
+++ b/templates/satosa/cdb.json.erb
@@ -1,0 +1,15 @@
+{
+  "platform": {
+    "response_types": ["code", "id_token"],
+    "client_id": "<%= @client_id %>",
+    "client_secret": "<%= @client_secret %>",
+    "claims_supported" : ["id_token"],
+    "redirect_uris": [
+      "https://platform.sunet.se/user/oauth2/platform/callback"
+    ],
+    "allowed_scope_values": [
+	    "profile",
+	    "email"
+    ]
+  }
+}

--- a/templates/satosa/cdb.json.erb
+++ b/templates/satosa/cdb.json.erb
@@ -5,7 +5,7 @@
     "client_secret": "<%= @client_secret %>",
     "claims_supported" : ["id_token"],
     "redirect_uris": [
-      "https://platform.sunet.se/user/oauth2/platform/callback"
+      "<%= @redirect_uri %>"
     ],
     "allowed_scope_values": [
 	    "profile",

--- a/templates/satosa/docker-compose.yml.erb
+++ b/templates/satosa/docker-compose.yml.erb
@@ -1,0 +1,19 @@
+version: '3.2'
+
+services:
+  always-https:
+    image: docker.sunet.se/always-https
+    ports:
+      - '80:80'
+    environment:
+      - 'ACME_URL=http://acme-c.sunet.se/'
+  satosa:
+    image: docker.sunet.se/satosa:<%= @tag %>
+    volumes:
+      - '/etc/satosa:/etc/satosa'
+      - '/etc/dehydrated:/etc/dehydrated'
+    ports:
+      - '443:8000'
+    environment:
+      - 'METADATA_DIR=/etc/satosa/metadata'
+      - 'WORKER_TIMEOUT=120'

--- a/templates/satosa/docker-compose.yml.erb
+++ b/templates/satosa/docker-compose.yml.erb
@@ -1,12 +1,14 @@
 version: '3.2'
 
 services:
+<% if @dehydrated_name %>
   always-https:
     image: docker.sunet.se/always-https
     ports:
       - '80:80'
     environment:
       - 'ACME_URL=http://acme-c.sunet.se/'
+<% end -%>
   satosa:
     image: docker.sunet.se/satosa:<%= @tag %>
     volumes:


### PR DESCRIPTION
Merge satosa classes from "all" ops repos so that we only need to maintain one class.

Can't find any ops repo that uses this class (`sunet::satosa`) so it should be safe to not be backwards compatible.

Some tweaks may be needed `cdb.json` when the class is used against a real Open Id Connect RP.