### PR TITLE
Correct use of boolean

### DIFF
--- a/templates/mastodon/web/mastodon.env.erb
+++ b/templates/mastodon/web/mastodon.env.erb
@@ -25,7 +25,7 @@ S3_PROTOCOL=https
 AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
 AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 S3_ALIAS_HOST=<%= @s3_alias_host %>
-RAILS_SERVE_STATIC_FILES=false
+RAILS_SERVE_STATIC_FILES=true
 OAUTH_REDIRECT_AT_SIGN_IN=true
 SAML_ENABLED=true
 SAML_ACS_URL=https://<%= @vhost %>/auth/auth/saml/callback


### PR DESCRIPTION
Mastodon pre 4.1.1 used any value as `true`. Change is backwards compatible.