### PR TITLE
No sunet::disable_resolved_stub by default

### DIFF
--- a/manifests/dockerhost.pp
+++ b/manifests/dockerhost.pp
@@ -366,9 +366,5 @@ class sunet::dockerhost(
         notify  => Service['unbound'],
         ;
     }
-  } else {
-    if $::facts['operatingsystem'] == 'Ubuntu' {
-      ensure_resource('class', 'sunet::disable_resolved_stub', { disable_resolved_stub => true, })
-    }
   }
 }


### PR DESCRIPTION
Stop calling sunet::disable_resolved_stub by default on Ubuntu machines. This results in us disabling the local systemd-resolve listener at 127.0.0.53:53 as well as pointing resolv.conf to the machines default IP and this should break DNS lookups if nothing is there to respond (which there shouldnt be, as reaching this else-statement means we do not configure a local unbound).

Without this change we had a problem where trying to set custom nameservers via netplan, the result of calling
sunet::disable_resolved_stub would create a file like this:
```
[Resolve]
DNS=A.B.C.D
DNSStubListener=no
```

And this would inject a "nameserver A.B.C.D" entry to the top of /etc/resolv.conf above out netplan managed nameservers when restarting 'systemd-resolved.service'.

Discussed with kano.