### PR TITLE
Add support for Debian 12

### DIFF
--- a/manifests/packages/cron.pp
+++ b/manifests/packages/cron.pp
@@ -1,0 +1,3 @@
+class sunet::packages::cron {
+    package { 'cron': ensure => installed }
+}

--- a/manifests/packages/puppet_module_camptocamp_augeas.pp
+++ b/manifests/packages/puppet_module_camptocamp_augeas.pp
@@ -1,0 +1,3 @@
+class sunet::packages::puppet_module_camptocamp_augeas {
+    package { 'puppet-module-camptocamp-augeas': ensure => installed }
+}

--- a/manifests/packages/puppet_module_puppetlabs_cron_core.pp
+++ b/manifests/packages/puppet_module_puppetlabs_cron_core.pp
@@ -1,0 +1,3 @@
+class sunet::packages::puppet_module_puppetlabs_cron_core {
+    package { 'puppet-module-puppetlabs-cron-core': ensure => installed }
+}

--- a/manifests/security/configure_sshd.pp
+++ b/manifests/security/configure_sshd.pp
@@ -40,7 +40,10 @@ class sunet::security::configure_sshd (
   } else {
     $set_port = undef
   }
-
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '12') >= 0 {
+    # These packages are needed to run the other things in this manifest on modern Debian
+    include sunet::packages::puppet_module_camptocamp_augeas
+  }
   include augeas
   augeas { 'sshd_config':
     context => '/files/etc/ssh/sshd_config',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,6 +15,12 @@ class sunet::server (
   Array $mgmt_addresses = [safe_hiera('mgmt_addresses', [])],
   Boolean $ssh_allow_from_anywhere = false,
 ) {
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '12') >= 0 {
+    # These packages are needed to run the other things in this manifest on modern Debian
+    include sunet::packages::cron
+    include sunet::packages::puppet_module_puppetlabs_cron_core
+    include sunet::packages::puppet_module_camptocamp_augeas
+  }
   if $fail2ban {
     # Configure fail2ban to lock out SSH scanners
     class { 'sunet::fail2ban': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -19,7 +19,6 @@ class sunet::server (
     # These packages are needed to run the other things in this manifest on modern Debian
     include sunet::packages::cron
     include sunet::packages::puppet_module_puppetlabs_cron_core
-    include sunet::packages::puppet_module_camptocamp_augeas
   }
   if $fail2ban {
     # Configure fail2ban to lock out SSH scanners


### PR DESCRIPTION
This patch allows sunet::server to be functional on debian 12, by installing cron and puppet modules for cron used by sunet::Server directly and augeas, that is used by sunet::security::configure_sshd