### PR TITLE
Create authorized keys

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,4 +86,10 @@ class sunet::server (
   if $facts['dmi']['product']['name'] == 'OpenStack Compute' {
     class { 'sunet::iaas::server': }
   }
+
+  # Set up ssh_authorized_keys
+  $ssh_authorized_keys = hiera_hash('ssh_authorized_keys', undef)
+  if is_hash($ssh_authorized_keys) {
+    create_resources('ssh_authorized_key', $ssh_authorized_keys)
+  }
 }


### PR DESCRIPTION
If the hash ssh_authorized_keys is defined, we should set up the corresponding resource. It seems now, everyone is doing this in cosmos-site.pp, which does not seem right.