### PR TITLE
Remove deprecated function calls to hiera and friends

### DIFF
--- a/lib/puppet/parser/functions/safe_hiera.rb
+++ b/lib/puppet/parser/functions/safe_hiera.rb
@@ -1,27 +1,28 @@
-#
-# This is a wrapped around the standard hiera() function to log warnings whenever
-# the resulting value is 'NOT_SET_IN_HIERA'.
-#
-# We use that as default value in lots of places where we don't want a missing
-# value to interrupt puppet completely (because it makes for a moment 22 problem
-# in bootstrapping new machines).
-#
-module Puppet::Parser::Functions
-  newfunction(:safe_hiera, :type => :rvalue) do |args|
+# frozen_string_literal: true
 
-    # Puppet 3.7
-    if Facter.value(:puppetversion).start_with? '3.7.'
-      value = function_hiera([args[0], 'NOT_SET_IN_HIERA'])
-    else
-      # Puppet >= 3.8 and Puppet 4.x
-      value = call_function('hiera', [args[0], 'NOT_SET_IN_HIERA'])
-    end
-    if value == 'NOT_SET_IN_HIERA'
-      warning("#{args[0]} not set in Hiera")
-      if args.size == 2
-        return args[1]
+module Puppet
+  module Parser
+    # This is a wrapped around the standard hiera() function to log warnings whenever
+    # the resulting value is 'NOT_SET_IN_HIERA'.
+    #
+    # We use that as default value in lots of places where we don't want a missing
+    # value to interrupt puppet completely (because it makes for a moment 22 problem
+    # in bootstrapping new machines).
+    module Functions
+      newfunction(:safe_hiera, type: :rvalue) do |args|
+        # Puppet 3.7
+        value = if Facter.value(:puppetversion).start_with? '3.7.'
+                  function_hiera([args[0], 'NOT_SET_IN_HIERA'])
+                else
+                  # Puppet >= 3.8
+                  call_function('hiera', [args[0], 'NOT_SET_IN_HIERA'])
+                end
+        if value == 'NOT_SET_IN_HIERA'
+          warning("#{args[0]} not set in Hiera")
+          return args[1] if args.size == 2
+        end
+        return value
       end
     end
-    return value
   end
 end

--- a/lib/puppet/parser/functions/safe_hiera.rb
+++ b/lib/puppet/parser/functions/safe_hiera.rb
@@ -6,7 +6,7 @@ module Puppet
     # the resulting value is 'NOT_SET_IN_HIERA'.
     #
     # We use that as default value in lots of places where we don't want a missing
-    # value to interrupt puppet completely (because it makes for a moment 22 problem
+    # value to interrupt puppet completely (because it makes for a catch 22 problem
     # in bootstrapping new machines).
     module Functions
       newfunction(:safe_hiera, type: :rvalue) do |args|

--- a/lib/puppet/parser/functions/safe_hiera.rb
+++ b/lib/puppet/parser/functions/safe_hiera.rb
@@ -2,7 +2,7 @@
 
 module Puppet
   module Parser
-    # This is a wrapped around the standard hiera() function to log warnings whenever
+    # This is a wrapped around the standard lookup() function to log warnings whenever
     # the resulting value is 'NOT_SET_IN_HIERA'.
     #
     # We use that as default value in lots of places where we don't want a missing
@@ -10,12 +10,12 @@ module Puppet
     # in bootstrapping new machines).
     module Functions
       newfunction(:safe_hiera, type: :rvalue) do |args|
-        # Puppet 3.7
         value = if Facter.value(:puppetversion).start_with? '3.7.'
+                  # Puppet 3.7
                   function_hiera([args[0], 'NOT_SET_IN_HIERA'])
                 else
                   # Puppet >= 3.8
-                  call_function('hiera', [args[0], 'NOT_SET_IN_HIERA'])
+                  call_function('lookup', [args[0].to_s, nil, nil, 'NOT_SET_IN_HIERA'])
                 end
         if value == 'NOT_SET_IN_HIERA'
           warning("#{args[0]} not set in Hiera")

--- a/manifests/baas.pp
+++ b/manifests/baas.pp
@@ -1,7 +1,7 @@
-# So this is the chaotic install instruct for the uber chaotic BaaS... 
+# So this is the chaotic install instruct for the uber chaotic BaaS...
 #
 #   1. First of all, create a node in the BaaS API and jot down (copy) the password.
-#   2. Use edit-secrets to give the password to the node BEFORE you run this, 
+#   2. Use edit-secrets to give the password to the node BEFORE you run this,
 #      use the syntax "baas_password: XXXXXX" in edit-secrets.
 #   3. Create a list in hiera with the directories to backup, similar to this:
 #      dirs_to_backup:
@@ -9,12 +9,11 @@
 #         - /opt/goodstuff/
 #      NOTE: These dirs_to_backup *MUST* have a trailing slash or they wont be backed!!!
 #   4. Call upon this module with the nodename, default also backs up subdirs.
-
-class sunet::baas(  
-   String $nodename,
-   $extra="-subdir=yes",
-   $src_url="https://api.cloud.ipnett.se/dist/tsm/mirror/maintenance/storage/tivoli-storage-management/maintenance/client/v7r1/Linux/LinuxX86_DEB/BA/v712/7.1.2.0-TIV-TSMBAC-LinuxX86_DEB.tar",
-   $cron=false,
+class sunet::baas(
+  String $nodename,
+  $extra='-subdir=yes',
+  $src_url='https://api.cloud.ipnett.se/dist/tsm/mirror/maintenance/storage/tivoli-storage-management/maintenance/client/v7r1/Linux/LinuxX86_DEB/BA/v712/7.1.2.0-TIV-TSMBAC-LinuxX86_DEB.tar',
+  $cron=false,
 ) {
 
   # Both these MUST be set properly in hiera to continue
@@ -22,64 +21,64 @@ class sunet::baas(
   $backup_dirs_not_empty = hiera('dirs_to_backup','NOT_SET_IN_HIERA')
 
   # This is silly but somehow you must know if BaaS has been installed already, if not you may break an already existing installation.
-  $control_file="/opt/tivoli/tsm/client/install_successful"
+  $control_file='/opt/tivoli/tsm/client/install_successful'
 
   if $baas_password != 'NOT_SET_IN_HIERA' and $backup_dirs_not_empty != 'NOT_SET_IN_HIERA' and $nodename {
     # These 2 rows to get a single string of all directories to backup + extras (flags normally)
     $dirs_to_backup_array = concat(hiera('dirs_to_backup','NOT_SET_IN_HIERA'), $extra)
     $dirs_to_backup = join($dirs_to_backup_array, ' ')
 
-    exec {"Create temp directory":
-       command => "/bin/mkdir -p /tmp/baas",
-       unless  => "test -f $control_file",
+    exec {'Create temp directory':
+      command => '/bin/mkdir -p /tmp/baas',
+      unless  => "test -f ${control_file}",
     }
 
-    sunet::remote_file { "/tmp/baas/baas.tar":
-       remote_location => $src_url,
-       mode            => "0600"
-    } ->
-    exec {"Unpack BaaS source code":
-       command => "tar xvf /tmp/baas/baas.tar -C /tmp/baas",
-       unless  => "test -f $control_file",
-    } ->
-    exec {"Install the debs from BaaS 1":
-       command => "dpkg -i /tmp/baas/gskcrypt64*deb /tmp/baas/gskssl64*deb",
-       unless  => "test -f $control_file",
-    } ->
-    exec {"Install the debs from BaaS 2":
-       command => "dpkg -i /tmp/baas/tivsm-api64*deb",
-       unless  => "test -f $control_file",
-    } ->
-    exec {"Install the debs from BaaS 3":
-       command => "dpkg -i /tmp/baas/tivsm-ba.*deb",
-       unless  => "test -f $control_file",
-    } ->
-    exec {"Install the debs from BaaS 4":
-       command => "dpkg -i /tmp/baas/tivsm-bacit*deb",
-       unless  => "test -f $control_file",
-    } ->
+    sunet::remote_file { '/tmp/baas/baas.tar':
+      remote_location => $src_url,
+      mode            => '0600'
+    }
+    -> exec {'Unpack BaaS source code':
+      command => 'tar xvf /tmp/baas/baas.tar -C /tmp/baas',
+      unless  => "test -f ${control_file}",
+    }
+    -> exec {'Install the debs from BaaS 1':
+      command => 'dpkg -i /tmp/baas/gskcrypt64*deb /tmp/baas/gskssl64*deb',
+      unless  => "test -f ${control_file}",
+    }
+    -> exec {'Install the debs from BaaS 2':
+      command => 'dpkg -i /tmp/baas/tivsm-api64*deb',
+      unless  => "test -f ${control_file}",
+    }
+    -> exec {'Install the debs from BaaS 3':
+      command => 'dpkg -i /tmp/baas/tivsm-ba.*deb',
+      unless  => "test -f ${control_file}",
+    }
+    -> exec {'Install the debs from BaaS 4':
+      command => 'dpkg -i /tmp/baas/tivsm-bacit*deb',
+      unless  => "test -f ${control_file}",
+    }
     # IBM...... so this keystore contains a password protected(!) public CA certificate
-    sunet::remote_file { "/tmp/baas/IPnett-Cloud-Root-CA.sh":
-       remote_location => "https://raw.githubusercontent.com/safespring/cloud-BaaS/master/pki/IPnett-Cloud-Root-CA.sh",
-       mode            => "755",
-    } ->
-    sunet::remote_file { "/tmp/baas/IPnett-Cloud-Root-CA.pem":
-       remote_location => "https://raw.githubusercontent.com/safespring/cloud-BaaS/master/pki/IPnett-Cloud-Root-CA.pem",
-       mode            => "440"
-    } ->
-    exec {"Install CA cert to keystore":
-       command => "/bin/sh /tmp/baas/IPnett-Cloud-Root-CA.sh && touch $control_file",
-       unless  => "test -f /opt/tivoli/tsm/client/ba/bin/dsmcert.kdb",
+    -> sunet::remote_file { '/tmp/baas/IPnett-Cloud-Root-CA.sh':
+      remote_location => 'https://raw.githubusercontent.com/safespring/cloud-BaaS/master/pki/IPnett-Cloud-Root-CA.sh',
+      mode            => '755',
     }
- 
+    -> sunet::remote_file { '/tmp/baas/IPnett-Cloud-Root-CA.pem':
+      remote_location => 'https://raw.githubusercontent.com/safespring/cloud-BaaS/master/pki/IPnett-Cloud-Root-CA.pem',
+      mode            => '440'
+    }
+    -> exec {'Install CA cert to keystore':
+      command => "/bin/sh /tmp/baas/IPnett-Cloud-Root-CA.sh && touch ${control_file}",
+      unless  => 'test -f /opt/tivoli/tsm/client/ba/bin/dsmcert.kdb',
+    }
+
     # These will probably never change but you never know so outside the chain :P
-    file { "/opt/tivoli/tsm/client/ba/bin/dsm.sys":
-       ensure  => "file",
-       content => template("sunet/baas/dsm_sys.erb")
+    file { '/opt/tivoli/tsm/client/ba/bin/dsm.sys':
+      ensure  => 'file',
+      content => template('sunet/baas/dsm_sys.erb')
     }
-    file { "/opt/tivoli/tsm/client/ba/bin/dsm.opt":
-       ensure  => "file",
-       content => template("sunet/baas/dsm_opt.erb")
+    file { '/opt/tivoli/tsm/client/ba/bin/dsm.opt':
+      ensure  => 'file',
+      content => template('sunet/baas/dsm_opt.erb')
     }
 
   }
@@ -87,18 +86,18 @@ class sunet::baas(
   if $cron {
   # FIXME: Add pass-through to be able to configure time of cronjob
     sunet::scriptherder::cronjob { 'backup_to_baas':
-       cmd           => "/usr/bin/dsmc incremental $dirs_to_backup",
-       minute        => '30',
-       hour          => '4',
-       ok_criteria   => ['exit_status=0', 'max_age=25h'],
-       warn_criteria => ['exit_status=0', 'max_age=49h'],
+      cmd           => "/usr/bin/dsmc incremental ${dirs_to_backup}",
+      minute        => '30',
+      hour          => '4',
+      ok_criteria   => ['exit_status=0', 'max_age=25h'],
+      warn_criteria => ['exit_status=0', 'max_age=49h'],
     }
   }
 
   # FIXME: This doesnt currently work because TSM requires a human to press enter to initiate a new host with dsmc
-  exec {"Initiate the new node in BaaS":
-     command => "dsmc query session -password=$baas_password",
-     unless  => "test -f /etc/adsm/TSM.PWD",
+  exec {'Initiate the new node in BaaS':
+    command => "dsmc query session -password=${baas_password}",
+    unless  => 'test -f /etc/adsm/TSM.PWD',
   }
 
 }

--- a/manifests/baas.pp
+++ b/manifests/baas.pp
@@ -17,15 +17,15 @@ class sunet::baas(
 ) {
 
   # Both these MUST be set properly in hiera to continue
-  $baas_password = hiera('baas_password', 'NOT_SET_IN_HIERA')
-  $backup_dirs_not_empty = hiera('dirs_to_backup','NOT_SET_IN_HIERA')
+  $baas_password = safe_hiera('baas_password')
+  $backup_dirs_not_empty = safe_hiera('dirs_to_backup')
 
   # This is silly but somehow you must know if BaaS has been installed already, if not you may break an already existing installation.
   $control_file='/opt/tivoli/tsm/client/install_successful'
 
   if $baas_password != 'NOT_SET_IN_HIERA' and $backup_dirs_not_empty != 'NOT_SET_IN_HIERA' and $nodename {
     # These 2 rows to get a single string of all directories to backup + extras (flags normally)
-    $dirs_to_backup_array = concat(hiera('dirs_to_backup','NOT_SET_IN_HIERA'), $extra)
+    $dirs_to_backup_array = concat(safe_hiera('dirs_to_backup'), $extra)
     $dirs_to_backup = join($dirs_to_backup_array, ' ')
 
     exec {'Create temp directory':

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -26,10 +26,10 @@
 # @param version           The version of the client to install
 # @param backup_dirs       Specific directories to backup, default is to backup everything
 class sunet::baas2(
-  String        $nodename="",
-  String        $tcpserveraddress="tsm12.backup.sto2.safedc.net",
+  String        $nodename='',
+  String        $tcpserveraddress='tsm12.backup.sto2.safedc.net',
   Boolean       $monitor_backups=true,
-  String        $version="8.1.17.2",
+  String        $version='8.1.17.2',
   Array[String] $backup_dirs = [],
 ) {
 
@@ -45,7 +45,7 @@ class sunet::baas2(
         regsubst($backup_dir,'/$','')
     }
 
-    file { "/usr/local/sbin/sunet-baas2-bootstrap":
+    file { '/usr/local/sbin/sunet-baas2-bootstrap':
       ensure  => 'file',
       mode    => '0755',
       owner   => 'root',
@@ -54,17 +54,17 @@ class sunet::baas2(
 
     # Make sure the requested version is installed
     exec { 'sunet-baas2-bootstrap --install':
-      command => "/usr/local/sbin/sunet-baas2-bootstrap --install --version=$version",
+      command => "/usr/local/sbin/sunet-baas2-bootstrap --install --version=${version}",
     }
 
     # Install the configuration files
-    file { "/opt/tivoli/tsm/client/ba/bin/dsm.sys":
-      ensure  => "file",
-      content => template("sunet/baas2/dsm.sys.erb")
+    file { '/opt/tivoli/tsm/client/ba/bin/dsm.sys':
+      ensure  => 'file',
+      content => template('sunet/baas2/dsm.sys.erb')
     }
-    file { "/opt/tivoli/tsm/client/ba/bin/dsm.opt":
-      ensure  => "file",
-      content => template("sunet/baas2/dsm.opt.erb")
+    file { '/opt/tivoli/tsm/client/ba/bin/dsm.opt':
+      ensure  => 'file',
+      content => template('sunet/baas2/dsm.opt.erb')
     }
 
     file { '/etc/systemd/system/dsmcad.service.d':
@@ -75,47 +75,47 @@ class sunet::baas2(
     }
 
     # Override dsmcad locale stuff to support more filenames when doing scheduled backups
-    file { "/etc/systemd/system/dsmcad.service.d/sunet.conf":
-      ensure => "file",
-      mode   => '0644',
-      owner  => 'root',
-      group  => 'root',
-      content => template("sunet/baas2/dsmcad.service.drop-in.erb")
+    file { '/etc/systemd/system/dsmcad.service.d/sunet.conf':
+      ensure  => 'file',
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      content => template('sunet/baas2/dsmcad.service.drop-in.erb')
     }
 
     # Make sure systemctl has picked up the above drop-in file
     exec { 'reload systemctl for dsmcad drop-in file':
-      command => 'systemctl daemon-reload',
-      subscribe => File['/etc/systemd/system/dsmcad.service.d/sunet.conf'],
+      command     => 'systemctl daemon-reload',
+      subscribe   => File['/etc/systemd/system/dsmcad.service.d/sunet.conf'],
       refreshonly => true,
     }
 
     # Make sure the client is registered with the server
     exec { 'sunet-baas2-bootstrap --register':
-      command => "/usr/local/sbin/sunet-baas2-bootstrap --register",
+      command     => '/usr/local/sbin/sunet-baas2-bootstrap --register',
       environment => [
-          "SUNET_BAAS_PASSWORD=$baas_password",
-          "SUNET_BAAS_ENCRYPTION_PASSWORD=$baas_encryption_password",
+          "SUNET_BAAS_PASSWORD=${baas_password}",
+          "SUNET_BAAS_ENCRYPTION_PASSWORD=${baas_encryption_password}",
       ],
-      require => File['/opt/tivoli/tsm/client/ba/bin/dsm.sys'],
+      require     => File['/opt/tivoli/tsm/client/ba/bin/dsm.sys'],
     }
 
     service { 'dsmcad':
-       ensure  => 'running',
-       enable  => true,
-       require => Exec['sunet-baas2-bootstrap --register'],
+      ensure  => 'running',
+      enable  => true,
+      require => Exec['sunet-baas2-bootstrap --register'],
     }
 
     if $monitor_backups {
-      file { "/usr/local/sbin/sunet-baas2-status":
+      file { '/usr/local/sbin/sunet-baas2-status':
         ensure  => 'file',
         mode    => '0755',
         owner   => 'root',
         content => file('sunet/baas2/sunet-baas2-status')
       }
 
-      sunet::scriptherder::cronjob { "sunet-baas2-status":
-        cmd         => "/usr/local/sbin/sunet-baas2-status",
+      sunet::scriptherder::cronjob { 'sunet-baas2-status':
+        cmd         => '/usr/local/sbin/sunet-baas2-status',
         minute      => '26',
         ok_criteria => ['exit_status=0', 'max_age=3h'],
       }

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -34,8 +34,8 @@ class sunet::baas2(
 ) {
 
   # MUST be set properly in hiera to continue
-  $baas_password = hiera('baas_password', 'NOT_SET_IN_HIERA')
-  $baas_encryption_password = hiera('baas_encryption_password', 'NOT_SET_IN_HIERA')
+  $baas_password = safe_hiera('baas_password')
+  $baas_encryption_password = safe_hiera('baas_encryption_password')
 
   if $nodename and $baas_password != 'NOT_SET_IN_HIERA' and $baas_encryption_password != 'NOT_SET_IN_HIERA' {
 

--- a/manifests/baas_repo.pp
+++ b/manifests/baas_repo.pp
@@ -9,14 +9,13 @@
 #         - /opt/goodstuff/
 #      NOTE: These dirs_to_backup *MUST* have a trailing slash or they wont be backed!!!
 #   4. Call upon this module with the nodename, remember default also backs up subdirs.
-
 class sunet::baas_repo(
-   String $nodename,
-   $extra="-subdir=yes",
-   $repo="https://repo.cloud.ipnett.com/debtest/",
-   $gpg_key="https://repo.cloud.ipnett.com/debtest/pubkey.gpg",
-   $gpg_file="/root/safespring_pubkey.gpg",
-   $cron=false,
+  String $nodename,
+  $extra='-subdir=yes',
+  $repo='https://repo.cloud.ipnett.com/debtest/',
+  $gpg_key='https://repo.cloud.ipnett.com/debtest/pubkey.gpg',
+  $gpg_file='/root/safespring_pubkey.gpg',
+  $cron=false,
 ) {
 
   # Both these MUST be set properly in hiera to continue
@@ -29,40 +28,40 @@ class sunet::baas_repo(
     $dirs_to_backup = join($dirs_to_backup_array, ' ')
 
     # This is a control file used to skip these semi-heavy installation steps
-    $control_file="/opt/tivoli/tsm/install_complete.txt"
+    $control_file='/opt/tivoli/tsm/install_complete.txt'
 
     # Grab PGP key from Safespring and add it & repo to sources
-    sunet::remote_file { "$gpg_file":
-       remote_location => $gpg_key,
-       mode            => "0600",
-    } ->
-    exec {"Add Safesprings key to chain & repo":
-       command => "apt-key add < $gpg_file && gpg --import $gpg_file",
-       unless  => "test -f $control_file",
-    } ->
-    exec {"Add Safesprings repository to sources and update":
-       command => "add-apt-repository $repo && apt-get update",
-       unless  => "test -f $control_file",
+    sunet::remote_file { $gpg_file:
+      remote_location => $gpg_key,
+      mode            => '0600',
+    }
+    -> exec {'Add Safesprings key to chain & repo':
+      command => "apt-key add < ${gpg_file} && gpg --import ${gpg_file}",
+      unless  => "test -f ${control_file}",
+    }
+    -> exec {'Add Safesprings repository to sources and update':
+      command => "add-apt-repository ${repo} && apt-get update",
+      unless  => "test -f ${control_file}",
     }
 
     # Time to install the stuff from Safesprings repository!
-    exec {"Install TSM stuff from Safespring":
-       command => "apt-get install safespring-baas-setup expect && touch $control_file",
+    exec {'Install TSM stuff from Safespring':
+      command => "apt-get install safespring-baas-setup expect && touch ${control_file}",
     }
 
     # These will probably never change but you never know so outside the chain :P
-    file { "/opt/tivoli/tsm/client/ba/bin/dsm.sys":
-       ensure  => "file",
-       content => template("sunet/baas/dsm_sys.erb")
+    file { '/opt/tivoli/tsm/client/ba/bin/dsm.sys':
+      ensure  => 'file',
+      content => template('sunet/baas/dsm_sys.erb')
     }
-    file { "/opt/tivoli/tsm/client/ba/bin/dsm.opt":
-       ensure  => "file",
-       content => template("sunet/baas/dsm_opt.erb")
+    file { '/opt/tivoli/tsm/client/ba/bin/dsm.opt':
+      ensure  => 'file',
+      content => template('sunet/baas/dsm_opt.erb')
     }
-    file { "/usr/local/bin/bootstrap-baas":
-       ensure  => "file",
-       mode    => "755",
-       content => template("sunet/baas/bootstrap-baas")
+    file { '/usr/local/bin/bootstrap-baas':
+      ensure  => 'file',
+      mode    => '0755',
+      content => template('sunet/baas/bootstrap-baas')
     }
 
   }
@@ -70,18 +69,18 @@ class sunet::baas_repo(
   if $cron {
   # FIXME: Add pass-through to be able to configure time of cronjob
     sunet::scriptherder::cronjob { 'backup_to_baas':
-       cmd           => "/usr/bin/dsmc incremental $dirs_to_backup",
-       minute        => '30',
-       hour          => '4',
-       ok_criteria   => ['exit_status=0', 'max_age=25h'],
-       warn_criteria => ['exit_status=0', 'max_age=49h'],
+      cmd           => "/usr/bin/dsmc incremental ${dirs_to_backup}",
+      minute        => '30',
+      hour          => '4',
+      ok_criteria   => ['exit_status=0', 'max_age=25h'],
+      warn_criteria => ['exit_status=0', 'max_age=49h'],
     }
   }
 
   # Because TSM we created an expect-script to get rid of human clickety-click needs
-  exec {"Initiate the new node in BaaS":
-     command => "/usr/local/bin/bootstrap-baas $nodename $baas_password",
-     unless  => "test -f /etc/adsm/TSM.KBD",
+  exec {'Initiate the new node in BaaS':
+    command => "/usr/local/bin/bootstrap-baas ${nodename} ${baas_password}",
+    unless  => 'test -f /etc/adsm/TSM.KBD',
   }
 
 }

--- a/manifests/baas_repo.pp
+++ b/manifests/baas_repo.pp
@@ -19,12 +19,12 @@ class sunet::baas_repo(
 ) {
 
   # Both these MUST be set properly in hiera to continue
-  $baas_password = hiera('baas_password', 'NOT_SET_IN_HIERA')
-  $backup_dirs_not_empty = hiera('dirs_to_backup','NOT_SET_IN_HIERA')
+  $baas_password = safe_hiera('baas_password')
+  $backup_dirs_not_empty = safe_hiera('dirs_to_backup')
 
   if $baas_password != 'NOT_SET_IN_HIERA' and $backup_dirs_not_empty != 'NOT_SET_IN_HIERA' and $nodename {
     # These 2 rows to get a single string of all directories to backup + extras (flags normally)
-    $dirs_to_backup_array = concat(hiera('dirs_to_backup','NOT_SET_IN_HIERA'), $extra)
+    $dirs_to_backup_array = concat(safe_hiera('dirs_to_backup'), $extra)
     $dirs_to_backup = join($dirs_to_backup_array, ' ')
 
     # This is a control file used to skip these semi-heavy installation steps

--- a/manifests/backuphost.pp
+++ b/manifests/backuphost.pp
@@ -3,7 +3,7 @@ class sunet::backuphost(
   String        $chroot,
   String        $mountpoint,
   String        $user   = 'backup',
-  Array[String] $allow_clients = hiera('backup_pfx'),
+  Array[String] $allow_clients = lookup('backup_pfx', Array[String], undef, ['130.242.125.68', '130.242.121.73']),
 ) {
   # parameters for sunet/backuphost/cron_free_diskspace.erb
   $free_diskspace_basedir = "${chroot}/incoming"
@@ -92,7 +92,7 @@ class sunet::backuphost(
     warn_criteria => ['exit_status=1'],
   }
 
-  $ssh_key_db = lookup('backup_ssh_keys')
+  $ssh_key_db = lookup('backup_ssh_keys', undef, undef, undef)
   if is_hash($ssh_key_db) {
     sunet::ssh_keys { 'backuphost':
       config   => { $user => keys($ssh_key_db) },

--- a/manifests/bird/peer.pp
+++ b/manifests/bird/peer.pp
@@ -9,7 +9,7 @@ define sunet::bird::peer(
   # gpg backend, so we couldn't put the password in secrets.yaml and just merge it in
   $password = $password_hiera_key ? {
     undef   => undef,
-    default => hiera($password_hiera_key, undef)
+    default => lookup($password_hiera_key, undef, undef, undef)
   }
 
   if is_ipaddr($remote_ip, 4) {

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -9,7 +9,7 @@ class sunet::dehydrated(
   Integer $server_port = 80,
   Integer $ssh_port = 22,
 ) {
-  $conf = hiera_hash('dehydrated')
+  $conf = lookup('dehydrated', undef, undef, undef)
   if $conf !~ Hash {
     fail("Hiera key 'dehydrated' is not a hash")
   }

--- a/manifests/docker_run.pp
+++ b/manifests/docker_run.pp
@@ -1,12 +1,12 @@
 # Common use of docker::run
 define sunet::docker_run(
   String $image,
-  String $imagetag           = hiera('sunet_docker_default_tag', 'latest'),
+  String $imagetag           = lookup('sunet_docker_default_tag', String, undef, 'latest'),
   Array[String] $volumes     = [],
   Array[String] $ports       = [],
   Array[String] $expose      = [],
   Array[String] $env         = [],
-  String $net                = hiera('sunet_docker_default_net', 'docker'),
+  String $net                = lookup('sunet_docker_default_net', String, undef 'docker'),
   Optional[String] $command  = undef,
   Optional[String] $hostname = undef,
   $depends                   = [],  # should be array of strings, but need to fix usage first

--- a/manifests/dockerhost.pp
+++ b/manifests/dockerhost.pp
@@ -6,8 +6,8 @@ class sunet::dockerhost(
   $storage_driver                             = undef,
   $docker_extra_parameters                    = undef,
   Boolean $run_docker_cleanup                 = true,
-  Variant[String, Boolean] $docker_network    = hiera('dockerhost_docker_network', '172.18.0.0/22'),
-  String $docker_network_v6                   = hiera('dockerhost_docker_network_v6', 'fd0c:d0c::/64'),  # default bridge
+  Variant[String, Boolean] $docker_network    = lookup('dockerhost_docker_network', Variant[String, Boolean], undef, '172.18.0.0/22'),
+  String $docker_network_v6                   = lookup('dockerhost_docker_network_v6', String, undef, 'fd0c:d0c::/64'),  # default bridge
   Variant[String, Array[String]] $docker_dns  = $facts['ipaddress_default'],
   Boolean $ufw_allow_docker_dns               = true,
   Boolean $manage_dockerhost_unbound          = false,

--- a/manifests/ds_389.pp
+++ b/manifests/ds_389.pp
@@ -9,7 +9,7 @@ class sunet::ds_389(
 )
 {
   $hostname = $facts['networking']['fqdn']
-  $dir_manager_password = lookup('dir_manager_password')
+  $dir_manager_password = lookup('dir_manager_password', undef, undef, undef)
   # Composefile
   sunet::docker_compose { '389_ds':
     content          => template('sunet/ds_389/docker-compose.erb.yml'),

--- a/manifests/flog.pp
+++ b/manifests/flog.pp
@@ -1,6 +1,6 @@
 class sunet::flog {
 
-   $postgres_password = hiera('flog_postgres_password', 'NOT_SET_IN_HIERA')
+   $postgres_password = safe_hiera('flog_postgres_password')
 
    file {'/var/docker':
        ensure => 'directory',

--- a/manifests/forgejo.pp
+++ b/manifests/forgejo.pp
@@ -17,27 +17,27 @@ class sunet::forgejo (
     env    => ['ACME_URL=http://acme-c.sunet.se'],
   }
   # gitea generate secret INTERNAL_TOKEN
-  $internal_token = hiera('internal_token')
+  $internal_token = lookup('internal_token', undef, undef, undef)
   # gitea generate secret JWT_SECRET
-  $jwt_secret = hiera('jwt_secret')
+  $jwt_secret = lookup('jwt_secret', undef, undef, undef)
   # gitea generate secret JWT_SECRET
-  $lfs_jwt_secret = hiera('lfs_jwt_secret')
+  $lfs_jwt_secret = lookup('lfs_jwt_secret', undef, undef, undef)
   # gitea generate secret SECRET_KEY
-  $secret_key = hiera('secret_key')
+  $secret_key = lookup('secret_key', undef, undef, undef)
   # SMTP Password from NOC
   $smtp_user = split($domain, '[.]')[0]
-  $smtp_password = hiera('smtp_password')
+  $smtp_password = lookup('smtp_password', undef, undef, undef)
 
   # S3 credentials from openstack
-  $s3_secret_key = hiera('s3_secret_key')
-  $s3_access_key = hiera('s3_access_key')
+  $s3_secret_key = lookup('s3_secret_key', undef, undef, undef)
+  $s3_access_key = lookup('s3_access_key', undef, undef, undef)
   $s3_host = 's3.sto4.safedc.net'
 
   # GPG password
-  $platform_sunet_se_gpg_password = hiera('platform_sunet_se_gpg_password')
+  $platform_sunet_se_gpg_password = lookup('platform_sunet_se_gpg_password', undef, undef, undef)
 
   # White list for email domains for account creation
-  $email_domain_whitelist = hiera('email_domain_whitelist')
+  $email_domain_whitelist = lookup('email_domain_whitelist', undef, undef, undef)
   # Nginx stuff
   file{ '/opt/nginx':
     ensure => directory,

--- a/manifests/frontend/load_balancer.pp
+++ b/manifests/frontend/load_balancer.pp
@@ -5,7 +5,7 @@
 class sunet::frontend::load_balancer(
   String  $router_id   = $ipaddress_default,
   String  $basedir     = '/opt/frontend',
-  Integer $base_uidgid = hiera('sunet_frontend_load_balancer_base_uidgid', 800),
+  Integer $base_uidgid = lookup('sunet_frontend_load_balancer_base_uidgid', Integer, undef, 800),
   Integer $frontend    = $base_uidgid + 0,
   Integer $fe_api      = $base_uidgid + 1,
   Integer $fe_monitor  = $base_uidgid + 2,
@@ -14,7 +14,7 @@ class sunet::frontend::load_balancer(
   Integer $telegraf    = $base_uidgid + 11,
   Integer $varnish     = $base_uidgid + 12,
 ) {
-  $config = hiera_hash('sunet_frontend')
+  $config = lookup('sunet_frontend', undef, undef, undef)
   if $config =~ Hash[String, Hash] {
     $confdir = "${basedir}/config"
     $scriptdir = "${basedir}/scripts"

--- a/manifests/frontend/load_balancer/peer.pp
+++ b/manifests/frontend/load_balancer/peer.pp
@@ -31,7 +31,7 @@ define sunet::frontend::load_balancer::peer(
   # gpg backend, so we couldn't put the password in secrets.yaml and just merge it in
   $md5 = $password_hiera_key ? {
     undef   => undef,
-    default => hiera($password_hiera_key, undef)
+    default => lookup($password_hiera_key, undef, undef, undef)
   }
 
   sunet::exabgp::neighbor { "peer_${name}":

--- a/manifests/frontend/load_balancer/website.pp
+++ b/manifests/frontend/load_balancer/website.pp
@@ -12,7 +12,7 @@ define sunet::frontend::load_balancer::website(
   }
   $site_name = pick($config['site_name'], $instance)
   $monitor_group = pick($config['monitor_group'], 'default')
-  $haproxy_template_dir = hiera('haproxy_template_dir', $instance)
+  $haproxy_template_dir = lookup('haproxy_template_dir', undef, undef, $instance)
 
   # Figure out what certificate to pass to the haproxy container
   if ! has_key($config, 'tls_certificate_bundle') {
@@ -94,7 +94,7 @@ define sunet::frontend::load_balancer::website(
   # This group is created by the exabgp package, but Puppet requires this before create_dir below
   ensure_resource('group', 'exabgp', {ensure => 'present'})
 
-  $local_config = hiera_hash('sunet_frontend_local', undef)
+  $local_config = lookup('sunet_frontend_local', undef, undef, undef)
   $config4 = deep_merge($config3, $local_config)
   # Setup directory where the 'config' container will read configuration data for this instance
   ensure_resource('sunet::misc::create_dir', ["${confdir}/${instance}",

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -11,7 +11,7 @@ define sunet::frontend::load_balancer::website2(
     notice("Instance name: ${instance} is longer than 12 characters and will not work in docker bridge networking, please rename instance.")
   }
   $site_name = pick($config['site_name'], $instance)
-  $haproxy_template_dir = hiera('haproxy_template_dir', $instance)
+  $haproxy_template_dir = lookup('haproxy_template_dir', undef, undef, $instance)
 
   if ! has_key($config, 'tls_certificate_bundle') {
     # Put suitable certificate path in $config['tls_certificate_bundle']
@@ -58,7 +58,7 @@ define sunet::frontend::load_balancer::website2(
     'frontend_fqdn' => $::fqdn,
   })
 
-  $local_config = hiera_hash('sunet_frontend_local', {})
+  $local_config = lookup('sunet_frontend_local', undef, undef, {})
   $config4 = deep_merge($config3, $local_config)
   ensure_resource('sunet::misc::create_dir', ["${confdir}/${instance}",
                                               "${confdir}/${instance}/certs",

--- a/manifests/frontend/route_reflector.pp
+++ b/manifests/frontend/route_reflector.pp
@@ -2,7 +2,7 @@
 class sunet::frontend::route_reflector(
   String $router_id = $::ipaddress_default,
 ) {
-  $config = hiera_hash('sunet_frontend')
+  $config = lookup('sunet_frontend', undef, undef, undef)
   if $config =~ Hash[String, Hash] {
     $ignore_peers_h = $config['route_reflector']['peers'].filter | $peer, $params | {
       has_key($params, 'monitor') and $params['monitor'] == false

--- a/manifests/gitlab.pp
+++ b/manifests/gitlab.pp
@@ -2,15 +2,15 @@ class sunet::gitlab {
 
     # Application specific password for Crowd.
     # The variable is used in the gitlab.rb template.
-    $crowd_password = hiera('crowd_password', 'NOT_SET_IN_HIERA')
+    $crowd_password = safe_hiera('crowd_password')
 
     # root password for the Gitlab app.
     # The variable is used in the gitlab.rb template.
-    $gitlab_root_password = hiera('gitlab_root_password', 'NOT_SET_IN_HIERA')
+    $gitlab_root_password = safe_hiera('gitlab_root_password')
 
     # Password for user gitlab in the PostgreSQL database.
     # The variable is used in the gitlab.rb template.
-    $postgres_gitlab_password = hiera('postgres_gitlab_password', 'NOT_SET_IN_HIERA')
+    $postgres_gitlab_password = safe_hiera('postgres_gitlab_password')
 
     # The following are used by the Gitlab container
     user { 'git': ensure => present,

--- a/manifests/gitolite.pp
+++ b/manifests/gitolite.pp
@@ -23,12 +23,12 @@ class sunet::gitolite(
     }
 
     $_ssh_key = $ssh_key ? {
-        undef   => safe_hiera("gitolite-admin-ssh-key",undef),
-        ""      => safe_hiera("gitolite-admin-ssh-key",undef),
+        undef   => lookup('gitolite-admin-ssh-key', undef, undef, undef),
+        ''      => lookup('gitolite-admin-ssh-key', undef, undef, undef),
         default => $ssh_key
     }
 
-    file { ["$home/.gitolite","$home/.gitolite/logs"]:
+    file { ["${home}/.gitolite","${home}/.gitolite/logs"]:
         ensure => directory,
         owner  => $username,
         group  => $group
@@ -51,8 +51,8 @@ class sunet::gitolite(
             }
         }
     } elsif $save_private_admin_key_on_server == false {
-        $gitolite_initial_public_admin_key = safe_hiera('gitolite-initial-public-admin-key', undef)
-        file { "$home/admin.pub":
+        $gitolite_initial_public_admin_key = lookup('gitolite-initial-public-admin-key', undef, undef, undef)
+        file { "${home}/admin.pub":
             ensure  => file,
             owner   => 'root',
             group   => 'root',
@@ -61,7 +61,7 @@ class sunet::gitolite(
     }
 
     package {'gitolite3': ensure => latest } ->
-    file { "$home/.gitolite.rc":
+    file { "${home}/.gitolite.rc":
         ensure  => file,
         owner   => $username,
         group   => $group,
@@ -69,9 +69,9 @@ class sunet::gitolite(
     } ->
 
     exec {'gitolite-setup':
-        command     => "gitolite setup -pk $home/admin.pub",
+        command     => "gitolite setup -pk ${home}/admin.pub",
         user        => $username,
-        environment => ["HOME=$home"]
+        environment => ["HOME=${home}"]
     }
 
     if $enable_git_daemon {

--- a/manifests/glb.pp
+++ b/manifests/glb.pp
@@ -12,7 +12,7 @@ class sunet::glb(
       ensure => 'directory'
    }
 
-   $geodns_key = safe_hiera('geodns_license',undef)
+   $geodns_key = safe_hiera('geodns_license')
 
    if $geodns_key != 'NOT_SET_IN_HIERA' {
 

--- a/manifests/hsm_client.pp
+++ b/manifests/hsm_client.pp
@@ -1,5 +1,5 @@
 class sunet::hsm_client($luna_version="6.2") {
-   $pkcs11pin = hiera('pkcs11pin',"")
+   $pkcs11pin = lookup('pkcs11pin', undef, undef, '')
    sunet::snippets::reinstall::keep {['/etc/luna','/etc/Chrystoki.conf.d']: } ->
    file {['/etc/luna','/etc/luna/cert']: ensure => directory } ->
    sunet::docker_run {"hsm_client_hsmproxy":

--- a/manifests/invent/receiver.pp
+++ b/manifests/invent/receiver.pp
@@ -4,7 +4,7 @@ class sunet::invent::receiver (
   String $interface  = 'ens3',
   String $vhost = 'invent.sunet.se'
 ){
-  $admin_password = lookup('invent_admin_password')
+  $admin_password = lookup('invent_admin_password', undef, undef, undef)
   $endpoints = ['hosts', 'images']
   $nginx_dirs = [ 'acme', 'certs','conf','dhparam','html','vhost' ]
 

--- a/manifests/luna_client.pp
+++ b/manifests/luna_client.pp
@@ -3,7 +3,7 @@ define sunet::luna_client($hostname = undef) {
       undef    => "${::fqdn}",
       default  => $hostname
    }
-   $pin = hiera("luna_partition_password")
+   $pin = lookup('luna_partition_password', undef, undef, undef)
    sunet::docker_run { "${name}-luna-client":
       image    => 'docker.sunet.se/luna-client',
       imagetag => 'latest',

--- a/manifests/mariadb.pp
+++ b/manifests/mariadb.pp
@@ -11,7 +11,7 @@ class sunet::mariadb(
   $wsrep_node_address = $facts['networking']['ip']
   $wsrep_node_name = $facts['networking']['fqdn']
   $server_id = 1000 + $id
-  $mysql_backup_password = lookup('mysql_backup_password')
+  $mysql_backup_password = lookup('mysql_backup_password', undef, undef, undef)
   $ports = [3306, 4444, 4567, 4568]
   sunet::misc::ufw_allow { 'mariadb_ports':
     from => $client_ips,

--- a/manifests/metadata/publisher.pp
+++ b/manifests/metadata/publisher.pp
@@ -21,8 +21,8 @@ class sunet::metadata::publisher(
          warn_criteria     => ['max_age=30m']
       }
    }
-   $ssh_key = safe_hiera('publisher_ssh_key',undef)
-   $ssh_key_type = safe_hiera('publisher_ssh_key_type',undef)
+   $ssh_key = lookup(publisher_ssh_key, undef, undef, undef)
+   $ssh_key_type = lookup(publisher_ssh_key_type, undef, undef, undef)
    if ($ssh_key and $ssh_key_type) {
       sunet::rrsync {$dir:
          ro                => false,

--- a/manifests/microk8s/node.pp
+++ b/manifests/microk8s/node.pp
@@ -106,7 +106,7 @@ class sunet::microk8s::node(
       }
     }
   }
-  $namespaces = hiera_hash('microk8s_secrets', {})
+  $namespaces = lookup('microk8s_secrets', undef, undef, {})
   $namespaces.each |String $namespace, Hash $secrets| {
       $secrets.each |String $name, Array $secret| {
         set_microk8s_secret($namespace, $name, $secret)

--- a/manifests/misc/create_key_file.pp
+++ b/manifests/misc/create_key_file.pp
@@ -16,7 +16,7 @@ define sunet::misc::create_key_file (
     default => $path,
   }
 
-  $key_content = hiera($hiera_key, 'NOT_SET_IN_HIERA')
+  $key_content = safe_hiera($hiera_key)
 
   if $key_content == 'NOT_SET_IN_HIERA' {
     warning ("Key file data key '${hiera_key}' not set in hiera")

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -1,7 +1,7 @@
 # Run naemon with Thruk
 class sunet::naemon_monitor(
   String $domain,
-  String $influx_password = hiera('influx_password'),
+  String $influx_password = lookup('influx_password', String, undef, ''),
   String $naemon_tag = 'latest',
   Array $naemon_extra_volumes = [],
   Array $resolvers = [],
@@ -46,7 +46,7 @@ class sunet::naemon_monitor(
 
   class { 'sunet::dehydrated::client': domain =>  $domain, ssl_links => true }
 
-  if hiera('shib_key',undef) != undef {
+  if lookup('shib_key', undef, undef, undef) != undef {
     sunet::snippets::secret_file { '/opt/naemon_monitor/shib-certs/sp-key.pem': hiera_key => 'shib_key' }
     # assume cert is in cosmos repo (overlay)
   }
@@ -55,6 +55,9 @@ class sunet::naemon_monitor(
   $thruk_users_string = inline_template('READONLY_USERS=<%- @thruk_users.each do |user| -%><%= user %>,<%- end -%>')
   $thruk_env = [ $thruk_admins_string, $thruk_users_string ]
 
+  if $influx_password == '' {
+    err('ERROR: influx password not set')
+  }
   $influx_env =  [ 'INFLUXDB_ADMIN_USER=admin',"INFLUXDB_ADMIN_PASSWORD=${influx_password}", 'INFLUXDB_DB=nagflux']
   $nagflux_env =  [ "INFLUXDB_ADMIN_PASSWORD=${influx_password}" ]
 

--- a/manifests/nagios.pp
+++ b/manifests/nagios.pp
@@ -10,9 +10,9 @@ class sunet::nagios(
   $procsc          = 200,
 ) {
 
-  $nagios_ip_v4 = hiera('nagios_ip_v4', '109.105.111.111')
-  $nagios_ip_v6 = hiera('nagios_ip_v6', '2001:948:4:6::111')
-  $nrpe_clients = hiera_array('nrpe_clients',['127.0.0.1','127.0.1.1',$nagios_ip_v4,$nagios_ip_v6])
+  $nagios_ip_v4 = lookup('nagios_ip_v4', undef, undef, '109.105.111.111')
+  $nagios_ip_v6 = lookup('nagios_ip_v6', undef, undef, '2001:948:4:6::111')
+  $nrpe_clients = lookup('nrpe_clients', undef, undef, ['127.0.0.1','127.0.1.1',$nagios_ip_v4,$nagios_ip_v6])
   #$allowed_hosts = "127.0.0.1,127.0.1.1,${nagios_ip_v4},${nagios_ip_v6}"
   $allowed_hosts = join($nrpe_clients,',')
 

--- a/manifests/nagiosapi.pp
+++ b/manifests/nagiosapi.pp
@@ -5,9 +5,9 @@ require stdlib
 
 class sunet::nagiosapi($version='latest',$api_port=5667) {
 
-   $nagios_ip_v4 = hiera('nagios_ip_v4', '109.105.111.111')
-   $nagios_ip_v6 = hiera('nagios_ip_v6', '2001:948:4:6::111')
-   $api_clients  = hiera_array('nagios_api_clients',['127.0.0.1','127.0.1.1',$nagios_ip_v4,$nagios_ip_v6])
+   $nagios_ip_v4 = lookup('nagios_ip_v4', undef, undef, '109.105.111.111', undef, undef, undef)
+   $nagios_ip_v6 = lookup('nagios_ip_v6', undef, undef, '2001:948:4:6::111', undef, undef, undef)
+   $api_clients  = lookup('nagios_api_clients', undef, undef, ['127.0.0.1','127.0.1.1',$nagios_ip_v4,$nagios_ip_v6])
 
    sunet::docker_run {'nagios-api':
       image    => 'docker.sunet.se/nagios-api',

--- a/manifests/noc.pp
+++ b/manifests/noc.pp
@@ -2,7 +2,7 @@
 class sunet::noc(
   Boolean $allow_reboot = true,
 ) {
-  $noc_ssh_keys = lookup('noc_ssh_keys')
+  $noc_ssh_keys = lookup('noc_ssh_keys', undef, undef, undef)
   # If we have Authorized keys for NOC staff, we create a user, 
   # add ssh keys there and allow them to run select commands
   if is_hash($noc_ssh_keys) {

--- a/manifests/norduni.pp
+++ b/manifests/norduni.pp
@@ -1,8 +1,8 @@
 class sunet::norduni {
 
-    $postgres_master_password = hiera('postgres_master_password', 'NOT_SET_IN_HIERA')
-    $postgres_ni_password = hiera('postgres_ni_password', 'NOT_SET_IN_HIERA')
-    $noclook_secret_key = hiera('noclook_secret_key', 'NOT_SET_IN_HIERA')
+    $postgres_master_password = safe_hiera('postgres_master_password')
+    $postgres_ni_password = safe_hiera('postgres_ni_password')
+    $noclook_secret_key = safe_hiera('noclook_secret_key')
     # TODO: Take tls info as arguments
     $norduni_tls_cert = 'nidev-consumer_nordu_net.crt'
     $norduni_tls_key = 'nidev-consumer_nordu_net.key'

--- a/manifests/onlyoffice/docs.pp
+++ b/manifests/onlyoffice/docs.pp
@@ -28,7 +28,7 @@ define sunet::onlyoffice::docs(
   }
 
   $amqp_env = ["AMQP_URI=${amqpuri}"]
-  $db_pwd = safe_hiera('document_db_password',undef)
+  $db_pwd = lookup(document_db_password, undef, undef, undef)
 
   $db_env = ["DB_HOST=${db_host}","DB_NAME=${db_name}","DB_USER=${db_user}","DB_TYPE=${db_type}"]
   $db_pwd_env = $db_pwd ? {
@@ -36,7 +36,7 @@ define sunet::onlyoffice::docs(
     default => ["DB_PWD=${db_pwd}"]
   }
 
-  $jwt_secret = safe_hiera('document_jwt_key',undef)
+  $jwt_secret = lookup(document_jwt_key, undef, undef, undef)
   $jwt_env = $jwt_secret ? {
     undef   => [],
     default => ['JWT_ENABLED=true',"JWT_SECRET=${jwt_secret}"]

--- a/manifests/pages.pp
+++ b/manifests/pages.pp
@@ -1,7 +1,7 @@
 require stdlib
 
 class sunet::pages($host='127.0.0.1',$port='5000',$version='latest') {
-   $config = hiera("sunet_pages_sites")
+   $config = lookup('sunet_pages_sites', undef, undef, undef)
    file { ['/var/www','/var/cache/sunetpages']: ensure => 'directory' } ->
    user {'www-data': ensure => present, system => true } ->
    sunet::docker_run { 'sunet-pages-api':

--- a/manifests/pkcs11_ca.pp
+++ b/manifests/pkcs11_ca.pp
@@ -2,14 +2,14 @@ class sunet::pkcs11_ca(
   String $ca_url,
   String $ca_dns_name,
   String $acme_root                      = '/acme',
-  String $pkcs11_sign_api_token          = lookup('pkcs11_sign_api_token'), # Example 'xyz' Taken from eyaml, here for clarity
+  String $pkcs11_sign_api_token          = lookup('pkcs11_sign_api_token', String, undef, ''), # Example 'xyz' Taken from eyaml, here for clarity
   String $pkcs11_token                   = 'my_test_token_1',
-  String $pkcs11_pin                     = lookup('pkcs11_pin'), # Example '1234' Taken from eyaml, here for clarity
+  String $pkcs11_pin                     = lookup('pkcs11_pin', String, undef, ''), # Example '1234' Taken from eyaml, here for clarity
   String $pkcs11_module                  = '/usr/lib/softhsm/libsofthsm2.so',
   String $postgres_host                  = 'postgres',
   String $postgres_database              = 'pkcs11_testdb1',
   String $postgres_user                  = 'pkcs11_testuser1',
-  String $postgres_password              = lookup('postgres_password'), # Example 'DBUserPassword' Taken from eyaml, here for clarity
+  String $postgres_password              = lookup('postgres_password', String, undef, ''), # Example 'DBUserPassword' Taken from eyaml, here for clarity
   String $postgres_port                  = '5432',
   String $postgres_timeout               = '5',
   String $postgres_image		 = 'postgres',
@@ -17,6 +17,9 @@ class sunet::pkcs11_ca(
 ) {
   include stdlib
 
+  if $pkcs11_sign_api_token == '' or $pkcs11_pin == '' or $postgres_password == '' {
+    err('ERROR: missing value in hiera for pkcs11_sign_api_token, pkcs11_pin or postgres_password')
+  }
 
   # clone down the pkcs11 code
   exec { 'pkcs11_ca_clone':

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -1,13 +1,13 @@
 class sunet::rsyslog(
   $daily_rotation = true,
-  $syslog_servers = hiera_array('syslog_servers',[]),
-  $relp_syslog_servers = hiera_array('relp_syslog_servers',[]),
+  $syslog_servers = lookup(syslog_servers, undef, undef, []),
+  $relp_syslog_servers = lookup(relp_syslog_servers, undef, undef, []),
   $single_log_file = true,
-  $syslog_enable_remote = safe_hiera('syslog_enable_remote','true'),
-  $udp_port = hiera('udp_port',undef),
-  $udp_client = hiera('udp_client',"any"),
-  $tcp_port = hiera('tcp_port',undef),
-  $tcp_client = hiera('tcp_client',"any"),
+  $syslog_enable_remote = lookup('syslog_enable_remote', undef, undef, 'true'),
+  $udp_port = lookup(udp_port, undef, undef, undef),
+  $udp_client = lookup('udp_client', undef, undef, 'any'),
+  $tcp_port = lookup(tcp_port, undef, undef, undef),
+  $tcp_client = lookup('tcp_client', undef, undef, 'any'),
   $traditional_file_format = false,
 ) {
   include stdlib

--- a/manifests/rt.pp
+++ b/manifests/rt.pp
@@ -3,10 +3,10 @@ class sunet::rt (
 ) {
 
     # Password for RT's root user
-    $rt_root_password = hiera('rt_root_password', 'NOT_SET_IN_HIERA')
+    $rt_root_password = safe_hiera('rt_root_password')
 
     # Password for postgres database
-    $postgres_password = hiera('postgres_password', 'NOT_SET_IN_HIERA')
+    $postgres_password = safe_hiera('postgres_password')
 
     # The following is used by the PostgreSQL container
     user { 'postgres': ensure => present,

--- a/manifests/satosa.pp
+++ b/manifests/satosa.pp
@@ -4,7 +4,7 @@ class sunet::satosa(
   String           $image           = 'docker.sunet.se/satosa',
   String           $interface       = $::facts['interface_default'],
   String           $satosa_tag      = '8.4.0',
-  Optional[String] $redirect_uri    = lookup('redirect_uri', undef, undef, ''),
+  Optional[String] $redirect_uri    = lookup('redirect_uri', Optional[String], undef, ''),
   Boolean          $enable_oidc     = false,
 ) {
 
@@ -16,10 +16,10 @@ class sunet::satosa(
     $service_to_notify = undef
   }
 
-  $proxy_conf = lookup('satosa_proxy_conf')
+  $proxy_conf = lookup('satosa_proxy_conf', undef, undef, undef)
   $default_conf = {
-    'STATE_ENCRYPTION_KEY'       => lookup('satosa_state_encryption_key'),
-    'USER_ID_HASH_SALT'          => lookup('satosa_user_id_hash_salt'),
+    'STATE_ENCRYPTION_KEY'       => lookup('satosa_state_encryption_key', undef, undef, undef),
+    'USER_ID_HASH_SALT'          => lookup('satosa_user_id_hash_salt', undef, undef, undef),
     'CUSTOM_PLUGIN_MODULE_PATHS' => ['plugins'],
     'COOKIE_STATE_NAME'          => 'SATOSA_STATE'
   }
@@ -34,7 +34,7 @@ class sunet::satosa(
     content  => file('sunet/md-signer2.crt')
   })
   ['backend','frontend','metadata'].each |$id| {
-    if lookup("satosa_${id}_key",undef, undef,undef) != undef {
+    if lookup("satosa_${id}_key", undef, undef, undef) != undef {
       sunet::snippets::secret_file { "/etc/satosa/${id}.key": hiera_key => "satosa_${id}_key" }
       # assume cert is in cosmos repo
     } else {
@@ -49,7 +49,7 @@ class sunet::satosa(
     content => inline_template("<%= @merged_conf.to_yaml %>\n"),
     notify  => $service_to_notify,
   }
-  $plugins = lookup('satosa_config')
+  $plugins = lookup('satosa_config', undef, undef, undef)
   sort(keys($plugins)).each |$n| {
     $conf = lookup($n)
     $fn = $plugins[$n]

--- a/manifests/scriptherder/cronjob.pp
+++ b/manifests/scriptherder/cronjob.pp
@@ -33,9 +33,9 @@ define sunet::scriptherder::cronjob(
     content => template('sunet/scriptherder/scriptherder_check.ini.erb'),
   }
 
-  if $special == 'daily' and hiera('scriptherder_daily_hour', undef) =~ Integer {
+  if $special == 'daily' and lookup(scriptherder_daily_hour, undef, undef, undef) =~ Integer {
     $_special = 'absent'
-    $_hour    = hiera('scriptherder_daily_hour')
+    $_hour    = lookup('scriptherder_daily_hour', undef, undef, undef)
     $_minute  = fqdn_rand(60, $safe_name)
   } else {
     $_special = $special

--- a/manifests/scriptherder/init.pp
+++ b/manifests/scriptherder/init.pp
@@ -11,7 +11,7 @@ class sunet::scriptherder::init (
   Boolean $nrpe             = true,
   Boolean $nrpe_sudo        = true,
   String  $scriptherder_dir = '/var/cache/scriptherder',
-  Integer $keep_days        = hiera('scriptherder_delete_older_than', 6),
+  Integer $keep_days        = lookup('scriptherder_delete_older_than', Integer, undef, 6),
 ) {
   if $install {
     if $::facts['operatingsystem'] == 'Ubuntu' and versioncmp($::facts['operatingsystemrelease'], '18.04') < 0 {

--- a/manifests/security/configure_sshd.pp
+++ b/manifests/security/configure_sshd.pp
@@ -3,7 +3,7 @@
 # @param port            The port to configure sshd to listen on. If undef, we leave it to sshd to decide.
 class sunet::security::configure_sshd (
   Boolean $configure_sftp = true,
-  Optional[Integer] $port = hiera('sunet_ssh_daemon_port', undef),
+  Optional[Integer] $port = lookup('sunet_ssh_daemon_port', Optional[integer], undef,  undef),
 ) {
   ensure_resource('package', 'openssh-server', {
       ensure => 'installed'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -12,7 +12,7 @@ class sunet::server (
   Boolean $apparmor = false,
   Boolean $disable_ipv6_privacy = false,
   Boolean $disable_all_local_users = false,
-  Array $mgmt_addresses = [safe_hiera('mgmt_addresses', [])],
+  Array $mgmt_addresses = [lookup('mgmt_addresses', undef, undef, [])],
   Boolean $ssh_allow_from_anywhere = false,
 ) {
   if $fail2ban {
@@ -31,7 +31,7 @@ class sunet::server (
   }
 
   if $sshd_config {
-    $ssh_port = hiera('sunet_ssh_daemon_port', undef)
+    $ssh_port = lookup(sunet_ssh_daemon_port, undef, undef, undef)
     class { 'sunet::security::configure_sshd':
       port => $ssh_port,
     }

--- a/manifests/snippets/secret_file.pp
+++ b/manifests/snippets/secret_file.pp
@@ -13,7 +13,8 @@ define sunet::snippets::secret_file(
     default  => $path
   }
   $safe_key = regsubst($hiera_key, '[^0-9A-Za-z_]', '_', 'G')
-  $data = lookup($hiera_key, undef, undef, lookup($safe_key, undef, undef, undef))
+  $default_data_from_safe_key = lookup($safe_key, undef, undef, undef)
+  $data = lookup($hiera_key, undef, undef, $default_data_from_safe_key)
   $decoded_data = $base64 ? {
     true     => base64('decode',$data),
     default  => $data

--- a/manifests/snippets/secret_file.pp
+++ b/manifests/snippets/secret_file.pp
@@ -13,7 +13,7 @@ define sunet::snippets::secret_file(
     default  => $path
   }
   $safe_key = regsubst($hiera_key, '[^0-9A-Za-z_]', '_', 'G')
-  $data = hiera($hiera_key, hiera($safe_key))
+  $data = lookup($hiera_key, undef, undef, lookup($safe_key, undef, undef, undef))
   $decoded_data = $base64 ? {
     true     => base64('decode',$data),
     default  => $data

--- a/manifests/telegraf.pp
+++ b/manifests/telegraf.pp
@@ -1,5 +1,5 @@
 class sunet::telegraf($repo = 'stable') {
-  $token = safe_hiera('influxdb_v2_token','NOT_SET_IN_HIERA');
+  $token = safe_hiera('influxdb_v2_token');
   if ($token == 'NOT_SET_IN_HIERA') {
      warning("Waiting to get influxdb_v2_token from hiera before configuring telegraf")
   } else {

--- a/manifests/telegraf/plugin.pp
+++ b/manifests/telegraf/plugin.pp
@@ -5,7 +5,7 @@ define sunet::telegraf::plugin($plugin=undef,$config=undef) {
          default => $plugin
       }
       $params = $config ? {
-         undef   => hiera("telegraf_plugin_$title",{}),
+         undef   => lookup("telegraf_plugin_$title", undef, undef, {}),
          default => $config
       }
       file { "/etc/telegraf/telegraf.d/$_plugin.conf": 

--- a/manifests/wordpress.pp
+++ b/manifests/wordpress.pp
@@ -28,7 +28,7 @@ define sunet::wordpress (
       undef   => "${name}",
       default => $mysql_db_name
    }
-   $pwd = hiera("${name}_db_password")
+   $pwd = lookup("${name}_db_password", undef, undef, undef)
    ensure_resource('file',["/data/${name}","/data/${name}/html","/data/${name}/credentials"], {ensure => directory})
    sunet::docker_run { "${name}_wordpress":
       image       => $wordpress_image,


### PR DESCRIPTION
Switch hiera('blablabla') -> lookup('blablabla', undef, undef, undef)
Switch hiera('blablabla', 'NOT_SET_IN_HIERA') -> safe_hiera('blablabla')
Switch hiera('blablabla', 'blabla') -> lookup('blablabla', undef, undef, 'blabla')
Switch hiera_array('blablabla', ['blabla']) -> lookup('blablabla', undef, undef, ['blabla'])
Switch safe_hiera('blablabla', 'NOT_SET_IN_HIERA') -> safe_hiera('blablabla')
Switch safe_hiera('blablabla', 'blabla') -> lookup('blablabla', undef, undef, 'blabla')

Note: If types are known at compiletime we also add that like:

String $str = lookup('str', String, undef, '')

Also switch the safe_hiera function over to lookup function in ruby code

More info on this here: https://www.puppet.com/docs/puppet/5.5/hiera_automatic.html#looking-up-data-with-hiera

Note: do not squash, there are lint commits here as well