### PR TITLE
Move requirements to metadata file

### DIFF
--- a/manifests/exabgp/monitor.pp
+++ b/manifests/exabgp/monitor.pp
@@ -17,7 +17,6 @@ define sunet::exabgp::monitor::url(
   Integer          $prio  = 10,
   String           $path  = '/etc/bgp/monitor.d',
 ) {
-   require stdlib
    $check_url = $url ? {
       undef   => $name,
       default => $url
@@ -40,7 +39,6 @@ define sunet::exabgp::monitor::haproxy(
   String  $hookdir   = '/etc/bgp/hooks',
   Integer $prio      = 10,
 ) {
-  require stdlib
   $site = $name
   ensure_resource('class','Sunet::Exabgp::Monitor', { path => $path, })
   $safe_title = regsubst($site, '[^0-9A-Za-z.\-]', '-', 'G')

--- a/manifests/kvm_base.pp
+++ b/manifests/kvm_base.pp
@@ -1,8 +1,5 @@
 # Create/start a KVM virtual machine
 # inspired by http://blogs.thehumanjourney.net/oaubuntu/entry/kvm_vmbuilder_puppet_really_automated
-
-require stdlib
-
 define sunet::kvm_base(
   $repo,
   $tagpattern,

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -19,8 +19,6 @@ class sunet::naemon_monitor(
   Optional[String] $default_host_group = undef,
 ){
 
-  require stdlib
-
   if $::facts['sunet_nftables_enabled'] == 'yes' {
       sunet::nftables::docker_expose { 'allow_http' :
       iif           => $interface,

--- a/manifests/nagiosapi.pp
+++ b/manifests/nagiosapi.pp
@@ -1,8 +1,5 @@
-require stdlib
-
 # TODO: enable the RW functions of the API at some point - need to mount nagios.cmd if exists
 # TODO: add tls frontend
-
 class sunet::nagiosapi($version='latest',$api_port=5667) {
 
    $nagios_ip_v4 = lookup('nagios_ip_v4', undef, undef, '109.105.111.111', undef, undef, undef)

--- a/manifests/pages.pp
+++ b/manifests/pages.pp
@@ -1,5 +1,3 @@
-require stdlib
-
 class sunet::pages($host='127.0.0.1',$port='5000',$version='latest') {
    $config = lookup('sunet_pages_sites', undef, undef, undef)
    file { ['/var/www','/var/cache/sunetpages']: ensure => 'directory' } ->

--- a/manifests/snippets/add_user_to_group.pp
+++ b/manifests/snippets/add_user_to_group.pp
@@ -1,6 +1,5 @@
 # Add a user to a group
 define sunet::snippets::add_user_to_group($username, $group) {
-  require stdlib
   ensure_resource('exec', "add_user_${username}_to_group_${group}_exec", {
     command => "adduser --quiet $username $group",
     path    => ['/usr/sbin', '/usr/bin', '/sbin', '/bin', ],

--- a/manifests/snippets/disable_bridge_nf.pp
+++ b/manifests/snippets/disable_bridge_nf.pp
@@ -1,6 +1,5 @@
 # Disable bridge nf
 define sunet::snippets::disable_bridge_nf() {
-  require stdlib
   augeas { 'server_bridge_nf_config':
     context => '/files/etc/sysctl.d/10-bridge-nf.conf',
     changes => [

--- a/manifests/snippets/disable_ipv6_privacy.pp
+++ b/manifests/snippets/disable_ipv6_privacy.pp
@@ -1,6 +1,5 @@
 # Disable IPv6 privacy extensions on servers. Complicates troubleshooting.
 define sunet::snippets::disable_ipv6_privacy() {
-  require stdlib
   augeas { 'server_ipv6_privacy_config':
     context => '/files/etc/sysctl.d/10-ipv6-privacy.conf',
     changes => [

--- a/manifests/snippets/encrypted_swap.pp
+++ b/manifests/snippets/encrypted_swap.pp
@@ -1,6 +1,5 @@
 # Encrypted swap
 define sunet::snippets::encrypted_swap() {
-  require stdlib
 
   package { 'ecryptfs-utils':
     ensure => 'installed'

--- a/manifests/snippets/ethernet_bonding.pp
+++ b/manifests/snippets/ethernet_bonding.pp
@@ -4,7 +4,6 @@
 # Bonding requires setup in /etc/network/interfaces as well.
 #
 define sunet::snippets::ethernet_bonding() {
-  require stdlib
   if $facts['is_virtual'] == 'false' and $facts['os']['name'] == 'Ubuntu' {
     if $facts['os']['release']['full'] <= '12.04' {
       package {'ifenslave': ensure => 'present' }

--- a/manifests/snippets/file_line.pp
+++ b/manifests/snippets/file_line.pp
@@ -1,6 +1,5 @@
 # from http://projects.puppetlabs.com/projects/puppet/wiki/Simple_Text_Patterns/5
 define sunet::snippets::file_line($filename, $line, $ensure = 'present') {
-  require stdlib
   case $ensure {
     default : { err ( "unknown ensure value ${ensure}" ) }
     present: {

--- a/manifests/snippets/keygen.pp
+++ b/manifests/snippets/keygen.pp
@@ -1,6 +1,5 @@
 # keygen
 define sunet::snippets::keygen($key_file=undef,$cert_file=undef,$size=4096,$days=3650) {
-  require stdlib
   exec { "${title}_key":
     command => "openssl genrsa -out ${key_file} ${size}",
     onlyif  => "test ! -f ${key_file}",

--- a/manifests/snippets/no_icmp_redirects.pp
+++ b/manifests/snippets/no_icmp_redirects.pp
@@ -1,6 +1,5 @@
 # No icmp redirects
 define sunet::snippets::no_icmp_redirects($order=10) {
-  require stdlib
   $cfg = "/etc/sysctl.d/${order}_${title}.conf";
   file { $cfg:
     ensure  => file,

--- a/manifests/snippets/reinstall/keep.pp
+++ b/manifests/snippets/reinstall/keep.pp
@@ -1,6 +1,5 @@
 # Keep
 define sunet::snippets::reinstall::keep() {
-  require stdlib
    $safe_name = regsubst($name, '[^0-9A-Za-z_]', '_', 'G')
    ensure_resource('file','/etc/sunet-reinstall.keep',{owner=>'root',group=>'root',mode=>'0644'})
    exec { "preserve_${safe_name}_during_reinstall":

--- a/manifests/snippets/secret_file.pp
+++ b/manifests/snippets/secret_file.pp
@@ -7,7 +7,6 @@ define sunet::snippets::secret_file(
   $mode      = '0400',
   $base64    = false
 ) {
-  require stdlib
   $thefile = $path ? {
     undef    => $name,
     default  => $path

--- a/manifests/snippets/somaxconn.pp
+++ b/manifests/snippets/somaxconn.pp
@@ -1,6 +1,5 @@
 # somaxconn
 define sunet::snippets::somaxconn($maxconn=512) {
-  require stdlib
   $cfg = "/etc/sysctl.d/${title}_somaxconn.conf";
   file { $cfg:
     ensure  => file,

--- a/manifests/snippets/ssh_command.pp
+++ b/manifests/snippets/ssh_command.pp
@@ -6,7 +6,6 @@ define sunet::snippets::ssh_command(
   $ssh_key_type = undef,
   $command      = 'ls /tmp'
 ) {
-  require stdlib
   $safe_name = regsubst($name, '[^0-9A-Za-z.\-]', '-', 'G')
 
   if ($manage_user) {

--- a/manifests/snippets/ssh_command2.pp
+++ b/manifests/snippets/ssh_command2.pp
@@ -6,7 +6,6 @@ define sunet::snippets::ssh_command2(
   String $user         = 'root',
   Boolean $manage_user = false,
 ) {
-  require stdlib
   $safe_name = regsubst($name, '[^0-9A-Za-z.\-]', '-', 'G')
 
   if ($manage_user) {

--- a/manifests/snippets/ssh_keygen.pp
+++ b/manifests/snippets/ssh_keygen.pp
@@ -1,6 +1,5 @@
 # Ssh keygen
 define sunet::snippets::ssh_keygen($key_file=undef) {
-  require stdlib
   $_key_file = $key_file ? {
     undef   => $name,
     default => $key_file

--- a/manifests/snippets/ssh_pubkey_from_privkey.pp
+++ b/manifests/snippets/ssh_pubkey_from_privkey.pp
@@ -1,6 +1,5 @@
 # pubkey from privkey
 define sunet::snippets::ssh_pubkey_from_privkey($privkey_file=undef) {
-  require stdlib
   $_privkey_file = $privkey_file ? {
     undef   => $name,
     default => $privkey_file

--- a/manifests/ssh_keyscan.pp
+++ b/manifests/ssh_keyscan.pp
@@ -1,6 +1,3 @@
-require stdlib
-require concat
-
 class sunet::ssh_keyscan(
   String $hostsfile,
   String $keyfile = '/etc/ssh/ssh_known_hosts',

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,13 @@
   "issues_url": "https://github.com/SUNET/puppet-sunet/issues",
   "description": "Slices and dices - mostly ubuntu",
   "dependencies": [
-  
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.25.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 4.1.0"
+    }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,12 +10,10 @@
   "description": "Slices and dices - mostly ubuntu",
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0"
+      "name": "puppetlabs/stdlib"
     },
     {
-      "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0"
+      "name": "puppetlabs/concat"
     }
   ]
 }


### PR DESCRIPTION
In puppet >= 7 we get an error when requiring classes across modules:

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Could not find class ::concat for internal-sto3-test-imap-1.mail.sunet.se (file: /etc/puppet/cosmos-modules/sunet/manifests/ssh_keyscan/host.pp, line: 6, column: 3) (file: /etc/puppet/cosmos-modules/sunet/manifests/dehydrated.pp, line: 285) on node internal-sto3-test-imap-1.mail.sunet.se
```

This patch adds information that there is a dependency on the   puppetlabs-concat and puppetlabs-stdlib modules to metadata.json, and removes the require clauses from the manifests (that were allways unneccessary). The classes and other resources are still available as puppet will resolve them without explicitly requiring them in the manifest. This has been tested on puppet 7.23.0 and puppet 5.5.22.