### PR TITLE
Make manage_ssh_key generate a valid key instead of creating a 0 byte…

### DIFF
--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -288,10 +288,10 @@ define sunet::dehydrated::client_define(
     undef   => $domain,
     default => $ssh_id,
   }
- if $manage_ssh_key {
+  if $manage_ssh_key {
     $key_path = "${home}/.ssh/id_${_ssh_id}"
     if lookup("${_ssh_id}_ssh_key", undef, undef, undef) { #Key is in secrets, write it to host
-      ensure_resource('sunet::snippets::secret_file', "$key_path", {
+      ensure_resource('sunet::snippets::secret_file', $key_path, {
       hiera_key => "${_ssh_id}_ssh_key",
       })
     }else{

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -288,10 +288,17 @@ define sunet::dehydrated::client_define(
     undef   => $domain,
     default => $ssh_id,
   }
-  if $manage_ssh_key {
-    ensure_resource('sunet::snippets::secret_file', "${home}/.ssh/id_${_ssh_id}", {
+ if $manage_ssh_key {
+    $key_path = "${home}/.ssh/id_${_ssh_id}"
+    if lookup("${_ssh_id}_ssh_key", undef, undef, undef) { #Key is in secrets, write it to host
+      ensure_resource('sunet::snippets::secret_file', "$key_path", {
       hiera_key => "${_ssh_id}_ssh_key",
       })
+    }else{
+      if (!find_file($key_path)){
+        sunet::snippets::ssh_keygen{$key_path:} #This will not overwrite an existing key
+      }
+    }
   }
   if $single_domain {
     cron { "rsync_dehydrated_${domain}":

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -294,7 +294,7 @@ define sunet::dehydrated::client_define(
       ensure_resource('sunet::snippets::secret_file', $key_path, {
       hiera_key => "${_ssh_id}_ssh_key",
       })
-    }else{
+    } else {
       if (!find_file($key_path)){
         sunet::snippets::ssh_keygen{$key_path:} #This will not overwrite an existing key
       }


### PR DESCRIPTION
Tested on debian bullseye. 