### PR TITLE
Fix nrpe check process

### DIFF
--- a/manifests/nagios/nrpe_check_process.pp
+++ b/manifests/nagios/nrpe_check_process.pp
@@ -5,9 +5,9 @@ define sunet::nagios::nrpe_check_process (
 
   include sunet::nagios::nrpe_check_process_command
 
-  $process_display_name = $alias ? {
+  $process_display_name = $display_name ? {
     undef   => $name,
-    default => $alias
+    default => $display_name
   }
   sunet::nagios::nrpe_command {"check_process_${name}":
     command_line => "/usr/lib/nagios/plugins/check_process -C PCPU -p ${name} -N ${process_display_name}"

--- a/manifests/nagios/nrpe_check_process.pp
+++ b/manifests/nagios/nrpe_check_process.pp
@@ -3,13 +3,7 @@ define sunet::nagios::nrpe_check_process (
   $display_name = undef
 ) {
 
-  file { '/usr/lib/nagios/plugins/check_process' :
-      ensure  => 'file',
-      mode    => '0751',
-      group   => 'nagios',
-      require => Package['nagios-nrpe-server'],
-      content => template('sunet/nagioshost/check_process.erb'),
-  }
+  include sunet::nagios::nrpe_check_process_command
 
   $process_display_name = $alias ? {
     undef   => $name,


### PR DESCRIPTION
If `sunet::nagios::nrpe_command` was called multiple times `puppet` would crash since the file statement was run more then once.