### PR TITLE
IBMs deb package is not compatible with Debian

### DIFF
--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -45,7 +45,7 @@ class sunet::baas2(
         refreshonly => true,
       }
       file { '/etc/ld.so.conf.d/puppet-sunet-baas2.conf':
-        content => '/usr/lib64\n',
+        content => "/usr/lib64\n",
         notify  => Exec['reload_ld_cache']
       }
     }

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -45,7 +45,7 @@ class sunet::baas2(
         refreshonly => true,
       }
       file { '/etc/ld.so.conf.d/puppet-sunet-baas2.conf':
-        content => '/usr/lib64',
+        content => '/usr/lib64\n',
         notify  => Exec['reload_ld_cache']
       }
     }

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -39,6 +39,17 @@ class sunet::baas2(
 
   if $nodename and $baas_password != 'NOT_SET_IN_HIERA' and $baas_encryption_password != 'NOT_SET_IN_HIERA' {
 
+    if $facts['os']['name'] == 'Debian' {
+      exec { 'reload_ld_cache':
+        command     => '/usr/sbin/ldconfig',
+        refreshonly => true,
+      }
+      file { '/etc/ld.so.conf.d/puppet-sunet-baas2.conf':
+        content => '/usr/lib64',
+        notify  => Exec['reload_ld_cache']
+      }
+    }
+
     # The dsm.sys template expects backup_dirs to not have a trailing slash, so
     # make sure this is the case
     $backup_dirs_transformed = $backup_dirs.map |$backup_dir| {


### PR DESCRIPTION
IBM have in their install scripts a special handle of Ubuntu where they link
all libs to /usr/lib which makes the dynamic linker find their libraries.

On Debian the dynamic linker can't find their libraries:
/usr/bin/dsmc: error while loading shared libraries: libgsk8ssl_64.so: cannot
open shared object file: No such file or directory

By adding this configuration to the linker it will extend it's search paths to
include where IBMs package install their libs.