### PR TITLE
Notify/subscribe are executed to late

### DIFF
--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -604,7 +604,7 @@ def fix_ldd() -> None:
         # Assume that the existing file contains the the requested content already
         pass
 
-    print("Flusing ldd cache")
+    print("Flushing ldd cache")
     # Flush the ldd cache
     subprocess.run("/usr/sbin/ldconfig", check=True)
 

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -603,10 +603,12 @@ def fix_ldd() -> None:
         # fix ldd is already run
         return
 
-    if not os.path.isfile(ldd_conf_file):
-        with open(ldd_conf_file, "w", encoding="utf-8") as file:
+    try:
+        with open(ldd_conf_file, "x", encoding="utf-8") as file:
             file.write("/usr/lib64\n")
             file.close()
+    except FileExistsError:
+        pass
 
     # Flush the ldd cache
     try:

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -526,7 +526,6 @@ def handle_installation(
 ) -> None:
     """Overall handler for installing the TSM client"""
     if installed_version != args.version:
-        fix_ldd()
         print(f"installing version: {args.version}")
         url = get_tar_url(args.version)
         print(f"url is: {url}")
@@ -535,6 +534,7 @@ def handle_installation(
         verify_file_hash(checksum_file)
         extract_tar_file(tar_file, download_dir)
         install_deb_files(download_dir)
+        fix_ldd()
 
     root_cert_needed = False
     root_cert_file = "/opt/tivoli/tsm/client/ba/bin/dsmcert.kdb"

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -601,7 +601,7 @@ def fix_ldd() -> None:
             print(f"Adding {file}")
             file.write("/usr/lib64\n")
     except FileExistsError:
-        # Assume the ldd cache is already handled
+        # Assume that the existing file contains the the requested content already
         pass
 
     print("Flusing ldd cache")

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -590,7 +590,12 @@ def handle_registration() -> None:
 
 
 def fix_ldd() -> None:
-    """Make sure the dynamic linker finds IBM's libraries"""
+    """Make sure the dynamic linker finds IBM's libraries
+    Without this fix Debian machines failed to run the IBM binaries since the linker
+    didn't include the diretory where IBM install it's libraries.
+
+    dsmc: error while loading shared libraries: libgsk8ssl_64.so: cannot open shared object file: No such file or directory # pylint:disable=line-too-long
+    """
 
     dist_info = platform.freedesktop_os_release()
     if dist_info["ID"] != "debian":

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -598,11 +598,13 @@ def fix_ldd() -> None:
     ldd_conf_file = "/etc/ld.so.conf.d/sunet-baas2.conf"
     try:
         with open(ldd_conf_file, "x", encoding="utf-8") as file:
+            print(f"Adding {file}")
             file.write("/usr/lib64\n")
     except FileExistsError:
         # Assume the ldd cache is already handled
         return
 
+    print("Flusing ldd cache")
     # Flush the ldd cache
     subprocess.run("/usr/sbin/ldconfig", check=True)
 

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -604,10 +604,7 @@ def fix_ldd() -> None:
         return
 
     # Flush the ldd cache
-    try:
-        subprocess.run("/usr/sbin/ldconfig", check=True)
-    except subprocess.CalledProcessError:
-        raise RuntimeError("unable to run '/usr/sbin/ldconfig'") from None
+    subprocess.run("/usr/sbin/ldconfig", check=True)
 
 
 if __name__ == "__main__":

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -601,7 +601,6 @@ def fix_ldd() -> None:
     try:
         with open(ldd_conf_file, "x", encoding="utf-8") as file:
             file.write("/usr/lib64\n")
-            file.close()
     except FileExistsError:
         # Assume the ldd cache is already handled
         return

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -484,15 +484,7 @@ def main() -> None:
     parser.add_argument(
         "--register", help="version of client to install", action="store_true"
     )
-    parser.add_argument(
-        "--fix-ldd",
-        help="Make sure the dynamic linker finds IBM's libraries",
-        action="store_true",
-    )
     args = parser.parse_args()
-
-    if args.fix_ldd:
-        fix_ldd()
 
     if args.install and not args.version:
         print("--install requires that you supply --version")
@@ -534,6 +526,7 @@ def handle_installation(
 ) -> None:
     """Overall handler for installing the TSM client"""
     if installed_version != args.version:
+        fix_ldd()
         print(f"installing version: {args.version}")
         url = get_tar_url(args.version)
         print(f"url is: {url}")

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -585,7 +585,7 @@ def handle_registration() -> None:
 def fix_ldd() -> None:
     """Make sure the dynamic linker finds IBM's libraries
     Without this fix Debian machines failed to run the IBM binaries since the linker
-    didn't include the diretory where IBM install it's libraries.
+    didn't include the directory where IBM install it's libraries.
 
     dsmc: error while loading shared libraries: libgsk8ssl_64.so: cannot open shared object file: No such file or directory # pylint:disable=line-too-long
     """

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -17,6 +17,7 @@ mypy --strict sunet-baas2-bootstrap
 import argparse
 import os
 import os.path
+import platform
 import shlex
 import shutil
 import struct
@@ -483,7 +484,15 @@ def main() -> None:
     parser.add_argument(
         "--register", help="version of client to install", action="store_true"
     )
+    parser.add_argument(
+        "--fix-ldd",
+        help="Make sure the dynamic linker finds IBM's libraries",
+        action="store_true",
+    )
     args = parser.parse_args()
+
+    if args.fix_ldd:
+        fix_ldd()
 
     if args.install and not args.version:
         print("--install requires that you supply --version")
@@ -578,6 +587,36 @@ def handle_registration() -> None:
     baas_encrypt_password = baas_encrypt_password.rstrip("\r\n")
 
     set_encrypt_password(encrypted_passwords_db, baas_encrypt_password)
+
+
+def fix_ldd() -> None:
+    """Make sure the dynamic linker finds IBM's libraries"""
+
+    dist_info = platform.freedesktop_os_release()
+    if not "debian" in dist_info["ID"]:
+        # This fix only applies to Debian
+        return
+
+    lock_file = "/var/lock/sunet-baas2-ldd"
+    ldd_conf_file = "/etc/ld.so.conf.d/sunet-baas2.conf"
+    if os.path.isfile(lock_file):
+        # fix ldd is already run
+        return
+
+    if not os.path.isfile(ldd_conf_file):
+        with open(ldd_conf_file, "w", encoding="utf-8") as file:
+            file.write("/usr/lib64\n")
+            file.close()
+
+    # Flush the ldd cache
+    try:
+        subprocess.run("/usr/sbin/ldconfig", capture_output=True, check=True)
+    except subprocess.CalledProcessError:
+        # Do not output the full command line since it contains secrets
+        raise RuntimeError("unable to run '/usr/sbin/ldconfig'") from None
+
+    with open(lock_file, "a", encoding="utf-8") as file:
+        file.close()
 
 
 if __name__ == "__main__":

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -602,7 +602,7 @@ def fix_ldd() -> None:
             file.write("/usr/lib64\n")
     except FileExistsError:
         # Assume the ldd cache is already handled
-        return
+        pass
 
     print("Flusing ldd cache")
     # Flush the ldd cache

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -597,27 +597,20 @@ def fix_ldd() -> None:
         # This fix only applies to Debian
         return
 
-    lock_file = "/var/lock/sunet-baas2-ldd"
     ldd_conf_file = "/etc/ld.so.conf.d/sunet-baas2.conf"
-    if os.path.isfile(lock_file):
-        # fix ldd is already run
-        return
-
     try:
         with open(ldd_conf_file, "x", encoding="utf-8") as file:
             file.write("/usr/lib64\n")
             file.close()
     except FileExistsError:
-        pass
+        # Assume the ldd cache is already handled
+        return
 
     # Flush the ldd cache
     try:
         subprocess.run("/usr/sbin/ldconfig", check=True)
     except subprocess.CalledProcessError:
         raise RuntimeError("unable to run '/usr/sbin/ldconfig'") from None
-
-    with open(lock_file, "a", encoding="utf-8") as file:
-        file.close()
 
 
 if __name__ == "__main__":

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -593,7 +593,7 @@ def fix_ldd() -> None:
     """Make sure the dynamic linker finds IBM's libraries"""
 
     dist_info = platform.freedesktop_os_release()
-    if not "debian" in dist_info["ID"]:
+    if dist_info["ID"] != "debian":
         # This fix only applies to Debian
         return
 

--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -612,9 +612,8 @@ def fix_ldd() -> None:
 
     # Flush the ldd cache
     try:
-        subprocess.run("/usr/sbin/ldconfig", capture_output=True, check=True)
+        subprocess.run("/usr/sbin/ldconfig", check=True)
     except subprocess.CalledProcessError:
-        # Do not output the full command line since it contains secrets
         raise RuntimeError("unable to run '/usr/sbin/ldconfig'") from None
 
     with open(lock_file, "a", encoding="utf-8") as file:

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -39,16 +39,6 @@ class sunet::baas2(
 
   if $nodename and $baas_password != 'NOT_SET_IN_HIERA' and $baas_encryption_password != 'NOT_SET_IN_HIERA' {
 
-    if $facts['os']['name'] == 'Debian' {
-      exec { 'reload_ld_cache':
-        command     => '/usr/sbin/ldconfig',
-        refreshonly => true,
-      }
-      file { '/etc/ld.so.conf.d/puppet-sunet-baas2.conf':
-        content => "/usr/lib64\n",
-        notify  => Exec['reload_ld_cache']
-      }
-    }
 
     # The dsm.sys template expects backup_dirs to not have a trailing slash, so
     # make sure this is the case
@@ -61,6 +51,11 @@ class sunet::baas2(
       mode    => '0755',
       owner   => 'root',
       content => file('sunet/baas2/sunet-baas2-bootstrap')
+    }
+
+    # Make sure the dynamic linker finds IBM's libraries
+    exec { 'sunet-baas2-bootstrap --fix-ldd':
+      command => '/usr/local/sbin/sunet-baas2-bootstrap --fix-ldd',
     }
 
     # Make sure the requested version is installed

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -53,11 +53,6 @@ class sunet::baas2(
       content => file('sunet/baas2/sunet-baas2-bootstrap')
     }
 
-    # Make sure the dynamic linker finds IBM's libraries
-    exec { 'sunet-baas2-bootstrap --fix-ldd':
-      command => '/usr/local/sbin/sunet-baas2-bootstrap --fix-ldd',
-    }
-
     # Make sure the requested version is installed
     exec { 'sunet-baas2-bootstrap --install':
       command => "/usr/local/sbin/sunet-baas2-bootstrap --install --version=${version}",


### PR DESCRIPTION
We need to update the library cache as soon as possible. It seems like the notify/subscribe commands are run to late in the process so the boostrap script failed due to lack of libraries.

By running the needed commands in a "regular" exec the order seems to be garanteed.