### PR TITLE
Prevents a reboot if the current node is a redis-master.

### DIFF
--- a/manifests/bankidp.pp
+++ b/manifests/bankidp.pp
@@ -156,7 +156,7 @@ class sunet::bankidp(
       numnodes => 2,
       hostmode => true,
       tls      => true,
-      automatic_rectify => true
+      automatic_rectify => true,
       prevent_reboot => true
     }
 

--- a/manifests/bankidp.pp
+++ b/manifests/bankidp.pp
@@ -157,6 +157,7 @@ class sunet::bankidp(
       hostmode => true,
       tls      => true,
       automatic_rectify => true
+      prevent_reboot => true
     }
 
     file { "/etc/ssl/certs/${fqdn}_infra.crt":


### PR DESCRIPTION
On by default for bankidp servers.