### PR TITLE
Allow multiple certs

### DIFF
--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -70,7 +70,7 @@ define sunet::frontend::load_balancer::website2(
   $numcerts = length($temp_certs)
   if $numcerts > 1 {
     $certnum = 0
-    $temp_certs.each do |$cert| {
+    $temp_certs.each |$cert| {
       if $cert != 'cer' {
         file { "${confdir}/${instance}/certs/tls_certificate_bundle.pem.${certnum}":
             source => $tls_certificate_bundle,

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -69,14 +69,12 @@ define sunet::frontend::load_balancer::website2(
   $temp_certs = shell_split($tls_certificate_bundle)
   $numcerts = length($temp_certs)
   if $numcerts > 1 {
-    $certnum = 0
-    $temp_certs.each |$cert| {
+    $temp_certs.each |Integer $index, String $cert| {
       if $cert != 'cer' {
-        file { "${confdir}/${instance}/certs/tls_certificate_bundle.pem.${certnum}":
+        file { "${confdir}/${instance}/certs/tls_certificate_bundle.pem.${index}":
             source => $tls_certificate_bundle,
             notify => Sunet::Docker_compose["frontend-${instance}"],
         }
-        $certnum += 1
       }
       file { "${confdir}/${instance}/certs/tls_certificate_bundle.pem":
           file => absent,

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -100,9 +100,10 @@ define sunet::frontend::load_balancer::website2(
       ;
   }
 
+
   # Parameters used in frontend/docker-compose_template.erb
   $dns                    = pick_default($config['dns'], [])
-  $exposed_ports          = pick_default($config['exposed_ports'], ["443"])
+  $exposed_ports          = pick_default($config['exposed_ports'], ['443'])
   $frontendtools_imagetag = pick($config['frontendtools_imagetag'], 'stable')
   $frontendtools_volumes  = pick($config['frontendtools_volumes'], false)
   $haproxy_image          = pick($config['haproxy_image'], 'docker.sunet.se/library/haproxy')

--- a/templates/frontend/docker-compose_template.erb
+++ b/templates/frontend/docker-compose_template.erb
@@ -22,7 +22,7 @@ services:
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.<%= index %>.pem:<%= cert %>:ro
     <%- index += 1 -%>
   <% end -%>
-<% else if @tls_certificate_bundle -%>
+<% elsif @tls_certificate_bundle -%>
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.pem:<%= @tls_certificate_bundle %>:ro
 <% else -%>
       # tls_certificate_bundle not set in Puppet

--- a/templates/frontend/docker-compose_template.erb
+++ b/templates/frontend/docker-compose_template.erb
@@ -17,11 +17,11 @@ services:
       - 'haproxy_data:/etc/haproxy'
       - 'haproxy_control:/var/run/haproxy-control'
 <% if @multi_certs.is_a? Array and @multi_certs.size > 1 -%>
-  <%- index = 0 -%>
-  <% @multi_certs.each do |cert| -%>
+<%- index = 0 -%>
+<% @multi_certs.each do |cert| -%>
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.<%= index %>.pem:<%= cert %>:ro
-    <%- index += 1 -%>
-  <% end -%>
+<%- index += 1 -%>
+<% end -%>
 <% elsif @tls_certificate_bundle -%>
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.pem:<%= @tls_certificate_bundle %>:ro
 <% else -%>

--- a/templates/frontend/docker-compose_template.erb
+++ b/templates/frontend/docker-compose_template.erb
@@ -16,8 +16,8 @@ services:
       - '/opt/frontend/scripts/haproxy-start.sh:/haproxy-start.sh:ro'
       - 'haproxy_data:/etc/haproxy'
       - 'haproxy_control:/var/run/haproxy-control'
-<% if @multi_certs.is_a? Array and @multi_certs.length > 1 -%>
-  <% index = 0 %>
+<% if @multi_certs.is_a? Array and @multi_certs.size > 1 -%>
+  <%- index = 0 -%>
   <% @multi_certs.each do |cert| -%>
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.<%= index %>.pem:<%= cert %>:ro
     <%- index += 1 -%>

--- a/templates/frontend/docker-compose_template.erb
+++ b/templates/frontend/docker-compose_template.erb
@@ -16,9 +16,9 @@ services:
       - '/opt/frontend/scripts/haproxy-start.sh:/haproxy-start.sh:ro'
       - 'haproxy_data:/etc/haproxy'
       - 'haproxy_control:/var/run/haproxy-control'
-<% if @multi_cert.is_a? Array and @multi_cert.size > 1 -%>
+<% if @multi_certs.is_a? Array and @multi_certs.length > 1 -%>
   <% index = 0 %>
-  <% @multi_cert.each do |cert| -%>
+  <% @multi_certs.each do |cert| -%>
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.<%= index %>.pem:<%= cert %>:ro
     <%- index += 1 -%>
   <% end -%>

--- a/templates/frontend/docker-compose_template.erb
+++ b/templates/frontend/docker-compose_template.erb
@@ -16,7 +16,13 @@ services:
       - '/opt/frontend/scripts/haproxy-start.sh:/haproxy-start.sh:ro'
       - 'haproxy_data:/etc/haproxy'
       - 'haproxy_control:/var/run/haproxy-control'
-<% if @tls_certificate_bundle -%>
+<% if @multi_cert.is_a? Array and @multi_cert.size > 1 -%>
+  <% index = 0 %>
+  <% @multi_cert.each do |cert| -%>
+      - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.<%= index %>.pem:<%= cert %>:ro
+    <%- index += 1 -%>
+  <% end -%>
+<% else if @tls_certificate_bundle -%>
       - /opt/frontend/config/<%= @instance %>/certs/tls_certificate_bundle.pem:<%= @tls_certificate_bundle %>:ro
 <% else -%>
       # tls_certificate_bundle not set in Puppet


### PR DESCRIPTION
With this patch set you can add multiple certificates to tls_certificates_bundle in this format:

```
tls_certificate_bundle: "/etc/ssl/private/kube.drive.test.sunet.dev_haproxy.crt crt  /etc/ssl/private/kube.drive.sunet.se_haproxy.crt"
```

That is, separated by the string ' crt '

The change is backwards compatible with the old solution and has been tested on drive frontends. Because of the usage of ' crt ' as seprator, {{ tls_certificate_bundle }} can still be used in your templates as before.