### PR TITLE
Use local freedesktop_os_release() on python < 3.10

### DIFF
--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -614,7 +614,7 @@ def fix_ldd() -> None:
     if int(python_version[0]) < 3:
         raise RuntimeError("only python 3 is supported")
 
-    if int(python_version[1]) < 8:
+    if int(python_version[1]) < 10:
         # We have our local implementation of platform_freedesktop_os_release() to
         # be usable on ubuntu 18.04. This can be cleaned up when there are no
         # ubuntu 18.04 users of the tool.


### PR DESCRIPTION
Turns out we need the local function on python 3.8 as well. That is the default for ubuntu-20.
This function is only available from python 3.10:
https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release