### PR TITLE
Due to Jsch bugs when only allowing ssh-ed25519 we use ecdsa for jenk…

### DIFF
--- a/templates/pypi/sshd_config.erb
+++ b/templates/pypi/sshd_config.erb
@@ -9,7 +9,7 @@ Port 22
 Protocol 2
 # HostKeys for protocol version 2
 #HostKey /etc/ssh/ssh_host_dsa_key
-#HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security
 UsePrivilegeSeparation yes


### PR DESCRIPTION
…ins->pypi.
https://github.com/jenkinsci/publish-over-ssh-plugin/issues/341