### PR TITLE
New baas2 client version + fix help text

### DIFF
--- a/files/baas2/sunet-baas2-bootstrap
+++ b/files/baas2/sunet-baas2-bootstrap
@@ -524,10 +524,10 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", help="version of client to install")
     parser.add_argument(
-        "--install", help="version of client to install", action="store_true"
+        "--install", help="install backup client", action="store_true"
     )
     parser.add_argument(
-        "--register", help="version of client to install", action="store_true"
+        "--register", help="register client with backup server", action="store_true"
     )
     args = parser.parse_args()
 

--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -33,7 +33,7 @@ class sunet::baas2(
   String        $nodename='',
   String        $tcpserveraddress='server2.backup.dco1.safedc.net',
   Boolean       $monitor_backups=true,
-  String        $version='8.1.17.2',
+  String        $version='8.1.22.0',
   Array[String] $backup_dirs = [],
   Array[String] $exclude_list = [],
   Boolean       $install_tbmr=false,


### PR DESCRIPTION
Bump the default backup client version to 8.1.22.0 and also fix som help text for script parameters.