### PR TITLE
updated scriptherder check for sunet infra cert

### DIFF
--- a/manifests/ici_ca.pp
+++ b/manifests/ici_ca.pp
@@ -42,10 +42,13 @@ define sunet::ici_ca::autosign(
 }
 
 # fetch certificate from ici-ca automatically and run a scriptherder job to see if it is valid
-define sunet::ici_ca::rp()
-{
+define sunet::ici_ca::rp(
+  Boolean $monitor_infra_cert = true,
+) {
+
   $host = $::fqdn
   $ca = $name
+
   file { '/usr/bin/dl_ici_cert':
     content => template('sunet/ici_ca/dl_ici_cert.erb'),
     mode    => '0755'
@@ -63,11 +66,13 @@ define sunet::ici_ca::rp()
     content => template('sunet/ici_ca/check_infra_cert_expire.erb'),
     mode    => '0755'
   }
-  sunet::scriptherder::cronjob { 'check_infra_cert':
-      cmd           => "/usr/bin/check_infra_cert_expire /etc/ssl/certs/${host}_infra.crt",
-      minute        => '30',
-      hour          => '8',
-      ok_criteria   => ['exit_status=0', 'max_age=26h'],
-      warn_criteria => ['exit_status=2', 'max_age=2d'],
+
+  if ($monitor_infra_cert) {
+    sunet::scriptherder::cronjob { 'check_infra_cert':
+        cmd           => "/usr/bin/check_infra_cert_expire /etc/ssl/certs/${host}_infra.crt",
+        minute        => '30',
+        hour          => '8',
+        ok_criteria   => ['exit_status=0', 'max_age=25h'],
     }
+  }
 }

--- a/templates/ici_ca/check_infra_cert_expire.erb
+++ b/templates/ici_ca/check_infra_cert_expire.erb
@@ -1,56 +1,18 @@
 #!/bin/sh
   
-# Checks if a given cert on disk will expire soon
-
-# Copyright 2009 Peter Palfrader
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#It is a changed version of the original https://github.com/sergioshev/nagios-plugins/blob/master/check_cert_expire
 
 set -u
 set -e
 
-# warn if expires within 2 weeks, critical if within a week or already is expired
-warn=1209600
+#ok if cert has minimum 2 weeks validity or more, critical if within a week or already is expired
+ok=1209600
 crit=604800
 
 usage() {
-        echo "Usage: $0 [-w seconds] [-c seconds] <certfile>" >&2
+        echo "Usage: $0 <certfile>" >&2
         exit 3
 }
-
-
-OPTS=$(getopt -o w:c: -n "$0" -- "$@") || usage
-
-eval set -- "$OPTS"
-
-while :; do
-        case "$1" in
-                -w) warn=$2; shift 2 ;;
-                -c) crit=$2; shift 2 ;;
-                --) shift; break; ;;
-                *) usage ;;
-        esac
-done
-if test "$crit" -gt "$warn"; then
-        warn=$crit
-fi
 
 if [ "$#" != 1 ]; then
         usage
@@ -65,12 +27,14 @@ fi
 
 expires=`openssl x509 -enddate -noout < "$cert"`
 
-if openssl x509 -checkend "$warn" -noout < "$cert" ; then
+if openssl x509 -checkend "$ok" -noout < "$cert" ; then
         echo "OK: $expires"
         exit 0
 fi
+
+
 if openssl x509 -checkend "$crit" -noout < "$cert" ; then
-        echo "WARN: $expires"
+        echo "CRITICAL: $expires"
         exit 2
 fi
 echo "CRITICAL: $expires"


### PR DESCRIPTION
Changes:

- Make the monitoring optional for services that do not bother about the validity of the certs
- Make the scriptherder check criticial if the cert is going to expire within two weeks or it is completely expired
- Warning for scriptherder is removed as the scriptherder check never becomes critical
- Adjust the script according to the scriptherder check