### PR TITLE
ubuntu24 fixes

### DIFF
--- a/manifests/nagios/nrpe_check_needrestart.pp
+++ b/manifests/nagios/nrpe_check_needrestart.pp
@@ -1,0 +1,12 @@
+# needrestart checks which daemons need to be restarted after library upgrades.
+define sunet::nagios::nrpe_check_needrestart (
+) {
+    sunet::sudoer {'nagios_run_needrestart_command':
+        user_name    => 'nagios',
+        collection   => 'nagios',
+        command_line => "/usr/sbin/needrestart -p -l"
+    }
+    sunet::nagios::nrpe_command {'check_needrestart':
+        command_line => "sudo /usr/sbin/needrestart -p -l"
+    }
+}

--- a/manifests/nagios/nrpe_check_total_procs_lax.pp
+++ b/manifests/nagios/nrpe_check_total_procs_lax.pp
@@ -3,7 +3,7 @@ define sunet::nagios::nrpe_check_total_procs_lax (
   Integer $critical = 200,
   Integer $warning = 150,
 ) {
-  if 'cosmos' in $facts and ('frontend_server' in $facts['cosmos']['host_roles']) {
+  if $facts =~ Hash and 'cosmos' in $facts and ('frontend_server' in $facts['cosmos']['host_roles']) {
     # There are more processes than normal on frontend hosts
     $_procw = $warning + 350
     $_procc = $critical + 350

--- a/manifests/nagios/nrpe_check_total_procs_lax.pp
+++ b/manifests/nagios/nrpe_check_total_procs_lax.pp
@@ -3,7 +3,7 @@ define sunet::nagios::nrpe_check_total_procs_lax (
   Integer $critical = 200,
   Integer $warning = 150,
 ) {
-  if is_hash($facts) and has_key($facts, 'cosmos') and ('frontend_server' in $facts['cosmos']['host_roles']) {
+  if 'cosmos' in $facts and ('frontend_server' in $facts['cosmos']['host_roles']) {
     # There are more processes than normal on frontend hosts
     $_procw = $warning + 350
     $_procc = $critical + 350

--- a/templates/kvm/mk_cloud_image.erb
+++ b/templates/kvm/mk_cloud_image.erb
@@ -23,6 +23,8 @@ install_options="<%= @install_options %>"
 sb_args="<%= @sb_args %>"
 os_info=""
 
+. /etc/os-release
+
 if ! echo "${install_options}" | grep -q -- '--osinfo'; then
     os_info_base="--osinfo "
     image_file=$(basename "${src_image}")
@@ -70,8 +72,10 @@ fi
 # solve bootstrapping of new kvm hosts where no vms exist already
 virsh pool-list | grep -qe "^\s*${pool_name}.*active" || {
     virsh pool-create-as --name "${pool_name}" --target "${images_dir}" --type dir --build
-    virsh pool-autostart "${pool_name}"
-    virsh pool-start "${pool_name}"
+    if dpkg --compare-versions ${VERSION_ID} lt 24.04 ; then
+        virsh pool-autostart "${pool_name}"
+        virsh pool-start "${pool_name}"
+    fi
 }
 virsh pool-refresh "${pool_name}"
 

--- a/templates/kvm/mk_cloud_image.erb
+++ b/templates/kvm/mk_cloud_image.erb
@@ -72,7 +72,7 @@ fi
 # solve bootstrapping of new kvm hosts where no vms exist already
 virsh pool-list | grep -qe "^\s*${pool_name}.*active" || {
     virsh pool-create-as --name "${pool_name}" --target "${images_dir}" --type dir --build
-    if dpkg --compare-versions ${VERSION_ID} lt 24.04 ; then
+    if dpkg --compare-versions "${VERSION_ID}" lt 24.04 ; then
         virsh pool-autostart "${pool_name}"
         virsh pool-start "${pool_name}"
     fi
@@ -109,7 +109,7 @@ fi
 if [ "x${rng}" != "x" ]; then
    install_options="${install_options} --rng='${rng}'"
 fi
-if dpkg --compare-versions ${VERSION_ID} ge 24.04 ; then
+if dpkg --compare-versions "${VERSION_ID}" ge 24.04 ; then
     install_options="${install_options} --import"
 fi
 

--- a/templates/kvm/mk_cloud_image.erb
+++ b/templates/kvm/mk_cloud_image.erb
@@ -109,6 +109,9 @@ fi
 if [ "x${rng}" != "x" ]; then
    install_options="${install_options} --rng='${rng}'"
 fi
+if dpkg --compare-versions ${VERSION_ID} ge 24.04 ; then
+    install_options="${install_options} --import"
+fi
 
 # destroy and undefine the domain if there is one (to allow reinstallation by removing the primary disk file)
 rm -f "/var/lib/libvirt/qemu/nvram/${hostname}_VARS.fd"  # need to remove UEFI NVRAM file if it exists


### PR DESCRIPTION
- Fixes for deprecated puppet syntax
- Fixes for libvirt 10 (default in ubuntu24)
- Add 'check_needrestart' that checks which daemons need to be restarted after library upgrades