### PR TITLE
Make sure we don't change behaviour for debian

### DIFF
--- a/templates/kvm/mk_cloud_image.erb
+++ b/templates/kvm/mk_cloud_image.erb
@@ -72,7 +72,7 @@ fi
 # solve bootstrapping of new kvm hosts where no vms exist already
 virsh pool-list | grep -qe "^\s*${pool_name}.*active" || {
     virsh pool-create-as --name "${pool_name}" --target "${images_dir}" --type dir --build
-    if dpkg --compare-versions "${VERSION_ID}" lt 24.04 ; then
+    if [ "${ID}" = "debian" ] || ([ "${ID}" = "ubuntu" ] && dpkg --compare-versions "${VERSION_ID}" lt 24.04) ; then
         virsh pool-autostart "${pool_name}"
         virsh pool-start "${pool_name}"
     fi
@@ -109,7 +109,7 @@ fi
 if [ "x${rng}" != "x" ]; then
    install_options="${install_options} --rng='${rng}'"
 fi
-if dpkg --compare-versions "${VERSION_ID}" ge 24.04 ; then
+if [ "${ID}" = "ubuntu" ] && dpkg --compare-versions "${VERSION_ID}" ge 24.04 ; then
     install_options="${install_options} --import"
 fi
 


### PR DESCRIPTION
Make if statements more precise so they do not affect _debian_ since that is not tested.

**if statement tests:**
```
$ cat test.sh
#!/bin/bash
#

. /etc/os-release

echo "ID: $ID"
echo "VERSION_ID: $VERSION_ID"

if [ "${ID}" = "debian" ] || ([ "${ID}" = "ubuntu" ] && dpkg --compare-versions "${VERSION_ID}" lt 24.04) ; then
  echo "ubuntu and less than 24.04 or debian"
else
  echo "no match"
fi
```
**ubuntu22:**
```
$ ./test.sh
ID: ubuntu
VERSION_ID: 22.04
ubuntu and less than 24.04 or debian
```
**ubuntu24:**
```
$ ./test.sh
ID: ubuntu
VERSION_ID: 24.04
no match
```
**debian12:**
```
$ ./test.sh
ID: debian
VERSION_ID: 12
ubuntu and less than 24.04 or debian
```