### PR TITLE
Mifr container registry fix

### DIFF
--- a/templates/forgejo/nginx.tmpl
+++ b/templates/forgejo/nginx.tmpl
@@ -305,6 +305,15 @@ proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
 proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 proxy_set_header X-Original-URI $request_uri;
 
+/* Try to work better when talking to docker container registry 
+taken from https://jfrog.com/help/r/artifactory-how-to-deal-with-pushing-larger-images-failure-in-artifactory-with-nginx-as-a-reverse-proxy/artifactory-how-to-deal-with-pushing-larger-images-failure-in-artifactory-with-nginx-as-a-reverse-proxy
+*/
+proxy_request_buffering off;
+proxy_max_temp_file_size 0; 
+client_max_body_size 0;
+proxy_read_timeout 3600;
+proxy_send_timeout 3600;
+
 # Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";
 {{- end }}

--- a/templates/forgejo/nginx.tmpl
+++ b/templates/forgejo/nginx.tmpl
@@ -305,14 +305,8 @@ proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
 proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 proxy_set_header X-Original-URI $request_uri;
 
-/* Try to work better when talking to docker container registry 
-taken from https://jfrog.com/help/r/artifactory-how-to-deal-with-pushing-larger-images-failure-in-artifactory-with-nginx-as-a-reverse-proxy/artifactory-how-to-deal-with-pushing-larger-images-failure-in-artifactory-with-nginx-as-a-reverse-proxy
-*/
-proxy_request_buffering off;
-proxy_max_temp_file_size 0; 
-client_max_body_size 0;
-proxy_read_timeout 3600;
-proxy_send_timeout 3600;
+client_max_body_size 512M;
+
 
 # Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";


### PR DESCRIPTION
Work around problem with pushing to registry gives "413 Request Entity Too Large". Not exhaustively tested to verify if we have a problem with chunked uploads. 
