### PR TITLE
Initial commit of sunet::chrony

### DIFF
--- a/manifests/chrony.pp
+++ b/manifests/chrony.pp
@@ -1,0 +1,53 @@
+# Install and configure chrony service. Default setup is client-only using NTS
+# time sources. If you want to act as NTP server see $allow_list.
+# Using the netnod NTS servers by default keeps us in line with MSBFS 2020:7
+# with their time service being traceable to UTC(SP).
+class sunet::chrony(
+  Array[String] $ntp_servers = [],
+  Array[String] $nts_servers = [
+    'gbg1.nts.netnod.se',
+    'gbg2.nts.netnod.se',
+    'lul1.nts.netnod.se',
+    'lul2.nts.netnod.se',
+    'mmo1.nts.netnod.se',
+    'mmo2.nts.netnod.se',
+    'sth1.nts.netnod.se',
+    'sth2.nts.netnod.se',
+    'svl1.nts.netnod.se',
+    'svl2.nts.netnod.se',
+  ],
+  Boolean $dhcp_time_sources = false,
+  Integer $cmdport = 0,
+  Array[String] $allow_list = [],
+  Array[String] $ntsservercerts = [],
+  Array[String] $ntsserverkeys = [],
+) {
+  package { 'chrony': ensure => 'installed' }
+
+  service { 'chrony':
+    ensure => running,
+    enable => true,
+  }
+
+  file { '/etc/chrony/chrony.conf':
+    ensure  => 'file',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    content => template('sunet/chrony/chrony.conf.erb'),
+    notify  => Service['chrony'],
+  }
+
+  exec { 'chronyc reload sources':
+      refreshonly => true,
+  }
+
+  file { '/etc/chrony/sources.d/sunet.sources':
+    ensure  => 'file',
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    content => template('sunet/chrony/sunet.sources.erb'),
+    notify  => Exec['chronyc reload sources'],
+  }
+}

--- a/manifests/chrony.pp
+++ b/manifests/chrony.pp
@@ -39,7 +39,7 @@ class sunet::chrony(
   }
 
   exec { 'chronyc reload sources':
-      refreshonly => true,
+    refreshonly => true,
   }
 
   file { '/etc/chrony/sources.d/sunet.sources':

--- a/templates/chrony/chrony.conf.erb
+++ b/templates/chrony/chrony.conf.erb
@@ -1,0 +1,72 @@
+# Managed by puppet.
+
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usable directives.
+
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d
+
+<% if @dhcp_time_sources -%>
+# Use time sources from DHCP.
+sourcedir /run/chrony-dhcp
+
+<% end -%>
+# Use NTP sources found in /etc/chrony/sources.d.
+sourcedir /etc/chrony/sources.d
+
+# This directive specify the location of the file containing ID/key pairs for
+# NTP authentication.
+keyfile /etc/chrony/chrony.keys
+
+# This directive specify the file into which chronyd will store the rate
+# information.
+driftfile /var/lib/chrony/chrony.drift
+
+# Save NTS keys and cookies.
+ntsdumpdir /var/lib/chrony
+
+# Uncomment the following line to turn logging on.
+#log tracking measurements statistics
+
+# Log files location.
+logdir /var/log/chrony
+
+# Stop bad estimates upsetting machine clock.
+maxupdateskew 100.0
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can't be used along with the 'rtcfile' directive.
+rtcsync
+
+# Step the system clock instead of slewing it if the adjustment is larger than
+# one second, but only in the first three clock updates.
+makestep 1 3
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+# This directive must be commented out when using time sources serving
+# leap-smeared time.
+leapsectz right/UTC
+
+<% if !@allow_list.empty? -%>
+# The allow directive configures chrony to open an NTP server port and allow
+# NTP requests from the given subnet. It also controls access of NTS-KE clients
+# when NTS is enabled on the server.
+<% @allow_list.each do |allow_subnet| -%>
+allow <%= allow_subnet %>
+<% end -%>
+
+<% end -%>
+<% if !@ntsservercerts.empty? and !@ntsserverkeys.empty? -%>
+# The ntsservercert+ntsserverkey directive configures chrony to open an NTS
+# server port for NTS-KE requests.
+<% @ntsservercerts.each do |ntsservercert| -%>
+ntsservercert <%= ntsservercert %>
+<% end -%>
+<% @ntsserverkeys.each do |ntsserverkey| -%>
+ntsserverkey <%= ntsserverkey %>
+<% end -%>
+
+<% end -%>
+# The port to listen for run-time monitoring commands. 0 means no port is
+# opened but local chronyc access is still possible through unix socket.
+cmdport <%= @cmdport %>

--- a/templates/chrony/sunet.sources.erb
+++ b/templates/chrony/sunet.sources.erb
@@ -1,0 +1,14 @@
+# Managed by puppet.
+<% if !@ntp_servers.empty? -%>
+# NTP sources:
+<% @ntp_servers.each do |ntp_server| -%>
+server <%= ntp_server %> iburst
+<% end -%>
+
+<% end -%>
+<% if !@nts_servers.empty? -%>
+# NTS sources:
+<% @nts_servers.each do |nts_server| -%>
+server <%= nts_server %> iburst nts
+<% end -%>
+<% end -%>


### PR DESCRIPTION
This is expected to be a replacement for sunet::ntp on Ubuntu 23.04 and newer as well as Debian 12 and newer (via later modification of sunet::server).

This module uses a default set of time sources from netnod to adhere to MSBFS 2020:7 which states machines should use time traceable to the official Swedish time UTC(SP).

It also defaults to using NTS over NTP to make our servers more resilient against MITM attacks trying to feed us bad time.

The chrony.conf template is basically a copy of the one supplied by Ubuntu/Debian with a few changes:
* Remove the default pool directives used by the Ubuntu/Debian configs and handle our own time sources by creating a sunet.sources file in the sources.d dir. These files can be reread via `chronyc reload sources` instead of restarting chrony.
* Set "cmdport 0": this removes a listening port 323 for chronyc commands. This is one less port to wonder about in netstat output and chronyc still works because it uses a unix socket by default.
* Toggle the usage of DHCP-learned NTP sources with a "dhcp_time_sources" argument, false by default. Since we want to use NTS it seems bad to possibly mix in ordinary NTP sources if a DHCP server happens to advertise them on a given network.

Finally you can also act as NTP server by adding entries to the allow_list argument which will make chrony open listening ports. This server operation can be further modified to handle NTS operation by supplying a NTS cert and key. Handling of such certs (e.g. via certbot or similar) is currently out of scope, but can possible be combined with something like sunet::certbot::acmed for automatic managemnt in the future.