### PR TITLE
Only install rng-tools on older kernels

### DIFF
--- a/manifests/tools.pp
+++ b/manifests/tools.pp
@@ -13,11 +13,25 @@ class sunet::tools {
   $extra_tools = $facts['os']['name'] ? {
     'Ubuntu' => ['update-manager-core',
                  'unattended-upgrades',
-                 'rng-tools',
                  ],
-    'Debian' => ['rng-tools5',
-                ],
     default => []
   }
-  ensure_resource(package, flatten([$debian_tools, $extra_tools]), {ensure => 'installed'})
+
+  # https://wiki.archlinux.org/title/Rng-tools
+  # Note: rng-tools is not needed anymore since Kernel 5.6 because /dev/random does not block anymore.
+  if versioncmp($facts['kernelmajversion'], '5.6') < 0 {
+    $rng_tools = $facts['os']['name'] ? {
+      'Ubuntu' => [
+        'rng-tools',
+      ],
+      'Debian' => [
+        'rng-tools5',
+      ],
+      default => []
+    }
+  } else {
+    $rng_tools = []
+  }
+
+  ensure_resource(package, flatten([$debian_tools, $extra_tools, $rng_tools]), {ensure => 'installed'})
 }


### PR DESCRIPTION
When working on a ubuntu 24.04 machine I saw this message on each cosmos run:
```
Notice: /Stage[main]/Sunet::Tools/Package[rng-tools]/ensure: created
```
This is because rng-tools is now a virtual package installing rng-tools-debian instead. Looking into this it seems rng-tools is not even useful for modern kernels, from
https://wiki.archlinux.org/title/Rng-tools:
```
Note: rng-tools is not needed anymore since Kernel 5.6 because /dev/random does not block anymore.
```
... so instead of pointing to rng-tools-debian or rng-tools5 on modern ubuntu machines just stop installing it for all machines with a kernel of 5.6 or later.