### PR TITLE
dockerhost2: include apt

### DIFF
--- a/manifests/dockerhost2.pp
+++ b/manifests/dockerhost2.pp
@@ -12,6 +12,8 @@ class sunet::dockerhost2(
   Boolean $nat                                = true,
 ) {
 
+  include apt
+
   $container_name_delimiter = '-'
   include sunet::packages::jq # restart_unhealthy_containers requirement
   include sunet::packages::python3_yaml # check_docker_containers requirement


### PR DESCRIPTION
This is expected by the module, and not doing so either causes warnings on puppet 7:
```
Warning: Unknown variable: 'apt::key_options'. (file: /usr/share/puppet/modules/apt/manifests/key.pp, line: 45, column: 123)
```
... or stops the run entirely on puppet 8:
```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Unknown variable: 'apt::key_options'. (file: /usr/share/puppet/modules/apt/manifests/key.pp, line: 45, column: 123) (file: /etc/puppet/cosmos-modules/sunet/manifests/dockerhost2.pp, line: 71) on node somehost-1.sunet.se
```