### PR TITLE
merge pahol-ubuntu24 fixes

### DIFF
--- a/manifests/nagios.pp
+++ b/manifests/nagios.pp
@@ -77,7 +77,7 @@ class sunet::nagios(
   sunet::nagios::nrpe_command {'check_zombie_procs':
     command_line => '/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z'
   }
-  if is_hash($facts) and has_key($facts, 'cosmos') and ('frontend_server' in $facts['cosmos']['host_roles']) {
+  if $facts =~ Hash and 'cosmos' in $facts and ('frontend_server' in $facts['cosmos']['host_roles']) {
     # There are more processes than normal on frontend hosts
     $_procw = $procsw + 350
     $_procc = $procsc + 350

--- a/manifests/pollinate.pp
+++ b/manifests/pollinate.pp
@@ -1,6 +1,6 @@
 define sunet::pollinate($device = '/dev/random') {
-  if ($::operatingsystem == 'Ubuntu') {
-    if ($::operatingsystemrelease == '12.04') {
+  if ($facts['os']['name'] == 'Ubuntu') {
+    if ($facts['os']['release']['full'] == '12.04') {
       apt::ppa {'ppa:ndn/pollen': }
     } else {
       apt::ppa {'ppa:ndn/pollen': ensure => absent }


### PR DESCRIPTION
Fix legacy facts and syntax that is incompatible with puppet8.x *(default in ubuntu24).