### PR TITLE
open just allowed ports

### DIFF
--- a/manifests/nftables/docker_expose.pp
+++ b/manifests/nftables/docker_expose.pp
@@ -52,9 +52,18 @@ define sunet::nftables::docker_expose (
           notify => Service['nftables'],
           ;
       }
-      sunet::nftables::allow { "expose-allow-${safe_name}":
-        from => 'any',
-        port => $port,
+      if ($allow_clients =~ Array[String, 1]) or ($allow_clients =~ String[1]) {
+        sunet::nftables::allow { "expose-allow-${safe_name}":
+          from => $allow_clients,
+          port => $port,
+          proto => $proto,
+        }
+      } else {
+          sunet::nftables::allow { "expose-allow-${safe_name}":
+            from => any,
+            port => $port,
+            proto => $proto,
+          }
       }
   }
 }


### PR DESCRIPTION
If the host runs `dockerhost2` and uses `sunet::nftables::docker_expose` to add rules, then `sunet::nftables::allow` is used. I added the logic that it will check if `$allow_clients` carry values. If it does, then it will restrict the opening of the port only to those clients. Additionally I added the paramete `proto` which was missing earlier.