### PR TITLE
stop docker adding ipv6 rules

### DIFF
--- a/templates/dockerhost/daemon2.json.erb
+++ b/templates/dockerhost/daemon2.json.erb
@@ -5,6 +5,7 @@
   "ip-forward": false,
   <% end -%>
   "iptables": false,
+  "ip6tables": false,
   "ip-masq": false,
   "default-address-pools": [
      {


### PR DESCRIPTION
docker-ce debian package version 5:27 adds ipv6 rules in nftables if the server or docker service is restared. We might as well stop it adding ipv6 rules along with ipv4 which is already in the configuration.