### PR TITLE
Smol fix to create a keyrings folder on older systems. 

### DIFF
--- a/.github/workflows/puppet-lint.yml
+++ b/.github/workflows/puppet-lint.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
           bundler-cache: true

--- a/manifests/otel/alloy.pp
+++ b/manifests/otel/alloy.pp
@@ -4,10 +4,10 @@ class sunet::otel::alloy (
   String $otel_receiver    = undef,
 ) {
   file { '/etc/apt/keyrings' :
-    ensure  => 'directory',
-    notify  => Service['alloy'],
-    mode    => '0644',
-    group   => 'root'
+    ensure => 'directory',
+    notify => Service['alloy'],
+    mode   => '0644',
+    group  => 'root'
   }
   file { '/etc/apt/keyrings/grafana.gpg' :
     ensure  => 'file',

--- a/manifests/otel/alloy.pp
+++ b/manifests/otel/alloy.pp
@@ -3,6 +3,12 @@
 class sunet::otel::alloy (
   String $otel_receiver    = undef,
 ) {
+  file { '/etc/apt/keyrings' :
+    ensure  => 'directory',
+    notify  => Service['alloy'],
+    mode    => '0644',
+    group   => 'root'
+  }
   file { '/etc/apt/keyrings/grafana.gpg' :
     ensure  => 'file',
     notify  => Service['alloy'],


### PR DESCRIPTION
Tested on debian11, but should apply to older ubuntu as well. 