### PR TITLE
Replace ntp with chrony on our servers

### DIFF
--- a/facts.d/chrony_enabled.sh
+++ b/facts.d/chrony_enabled.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+enabled="no"
+
+if [ -f /etc/sunet-chrony-opt-in ]; then
+    enabled="yes"
+fi
+
+vendor=$(lsb_release -is)
+version=$(lsb_release -rs)
+test "$vendor" = "Debian" && dpkg --compare-versions "${version}" "ge" "12" && enabled="yes"
+test "$vendor" = "Ubuntu" && dpkg --compare-versions "${version}" "ge" "23.04" && enabled="yes"
+
+echo "sunet_chrony_enabled=${enabled}"

--- a/manifests/chrony.pp
+++ b/manifests/chrony.pp
@@ -22,6 +22,28 @@ class sunet::chrony(
   Array[String] $ntsservercerts = [],
   Array[String] $ntsserverkeys = [],
 ) {
+
+  ### BEGIN sunet::ntp cleanup
+  # Cleanup potential remains from previous usage of sunet::ntp
+  package { 'ntp': ensure => 'purged' }
+  package { 'ntpsec': ensure => 'purged' }
+
+  # Some files that are left behind even after purge because they are created
+  # manually by sunet::ntp on Ubuntu.
+  if $facts['os']['distro']['id'] == 'Ubuntu' {
+    include sunet::systemd_reload
+
+    file { '/etc/systemd/system/multi-user.target.wants/ntp.service':
+      ensure => 'absent',
+      notify => [Class['sunet::systemd_reload']]
+    }
+    file { '/etc/systemd/system/ntp.service':
+      ensure => 'absent',
+      notify => [Class['sunet::systemd_reload']]
+    }
+  }
+  ### END sunet::ntp cleanup
+
   package { 'chrony': ensure => 'installed' }
 
   service { 'chrony':

--- a/manifests/ntp.pp
+++ b/manifests/ntp.pp
@@ -12,9 +12,8 @@ class sunet::ntp(
   # Only do anything on older Ubuntu and Debian. For later versions
   # sunet::server will use sunet::chrony instead. This if-statement is needed
   # because not every ops-repo uses sunet::server to select what ntp class to
-  # use. If changing this if-statement you might need to update it in
-  # sunet::server as well.
-  if ($distro == 'Ubuntu' and versioncmp($release, '22.04') <= 0) or ($distro == 'Debian' and versioncmp($release, '11') <= 0) {
+  # use.
+  if $::facts['sunet_chrony_enabled'] != 'yes' {
     # Help Puppet understand to use systemd for Ubuntu 16.04 hosts
     if $distro == 'Ubuntu' and versioncmp($release, '15.04') >= 0 {
       Service {

--- a/manifests/ntp.pp
+++ b/manifests/ntp.pp
@@ -7,7 +7,7 @@ class sunet::ntp(
 
   # Get facts for distro/release
   $distro = $facts['os']['distro']['id']
-  $release = $facts['os']['distro']['release']['full']
+  $release = $facts['os']['distro']['release']['major']
 
   # Only do anything on older Ubuntu and Debian. For later versions
   # sunet::server will use sunet::chrony instead. This if-statement is needed

--- a/manifests/ntp.pp
+++ b/manifests/ntp.pp
@@ -9,62 +9,69 @@ class sunet::ntp(
   $distro = $facts['os']['distro']['id']
   $release = $facts['os']['distro']['release']['full']
 
-  # Help Puppet understand to use systemd for Ubuntu 16.04 hosts
-  if $distro == 'Ubuntu' and versioncmp($release, '15.04') >= 0 {
-    Service {
-      provider => 'systemd',
+  # Only do anything on older Ubuntu and Debian. For later versions
+  # sunet::server will use sunet::chrony instead. This if-statement is needed
+  # because not every ops-repo uses sunet::server to select what ntp class to
+  # use. If changing this if-statement you might need to update it in
+  # sunet::server as well.
+  if ($distro == 'Ubuntu' and versioncmp($release, '22.04') <= 0) or ($distro == 'Debian' and versioncmp($release, '11') <= 0) {
+    # Help Puppet understand to use systemd for Ubuntu 16.04 hosts
+    if $distro == 'Ubuntu' and versioncmp($release, '15.04') >= 0 {
+      Service {
+        provider => 'systemd',
+      }
     }
-  }
 
-  package { 'ntp': ensure => 'installed' }
-  service { 'ntp':
-    ensure     => running,
-    name       => 'ntp',
-    enable     => true,
-    hasrestart => true,
-    require    => Package['ntp'],
-  }
-
-  # Don't use pool.ntp.org servers, but rather DHCP provided NTP servers
-  $_disable_pool = $disable_pool_ntp_org ? {
-    true => ['rm pool[.]'],
-    false => [],
-  }
-
-  # in cases where DHCP does not provide servers, or the machinery doesn't
-  # work well (Ubuntu 16.04, looking at you), add some servers manually
-  $_set_servers = map(flatten([$set_servers, $add_servers])) |$index, $server| {
-    sprintf('set server[%s] %s', $index + 1, $server)
-  }
-  $changes = flatten([$_disable_pool,
-                      $_set_servers ? {
-                        [] => [],
-                        default => ['rm server[.]',
-                                    $_set_servers],
-                      },])
-
-  if $changes != [] {
-    include augeas
-
-    augeas { 'ntp.conf':
-      context => '/files/etc/ntp.conf',
-      changes => $changes,
-      require => Package['ntp'],
-      notify  => Service['ntp'],
+    package { 'ntp': ensure => 'installed' }
+    service { 'ntp':
+      ensure     => running,
+      name       => 'ntp',
+      enable     => true,
+      hasrestart => true,
+      require    => Package['ntp'],
     }
-  }
 
-  if $distro == 'Ubuntu' and versioncmp($release, '15.04') >= 0 {
-    include sunet::systemd_reload
+    # Don't use pool.ntp.org servers, but rather DHCP provided NTP servers
+    $_disable_pool = $disable_pool_ntp_org ? {
+      true => ['rm pool[.]'],
+      false => [],
+    }
 
-    # replace init.d script with systemd service file to get Restart=always
-    file {
-      '/etc/systemd/system/ntp.service':
-        content => template('sunet/ntp/ntp.service.erb'),
-        notify  => [Class['sunet::systemd_reload'],
-                    Service['ntp'],
-                    ],
-        ;
+    # in cases where DHCP does not provide servers, or the machinery doesn't
+    # work well (Ubuntu 16.04, looking at you), add some servers manually
+    $_set_servers = map(flatten([$set_servers, $add_servers])) |$index, $server| {
+      sprintf('set server[%s] %s', $index + 1, $server)
+    }
+    $changes = flatten([$_disable_pool,
+                        $_set_servers ? {
+                          [] => [],
+                          default => ['rm server[.]',
+                                      $_set_servers],
+                        },])
+
+    if $changes != [] {
+      include augeas
+
+      augeas { 'ntp.conf':
+        context => '/files/etc/ntp.conf',
+        changes => $changes,
+        require => Package['ntp'],
+        notify  => Service['ntp'],
+      }
+    }
+
+    if $distro == 'Ubuntu' and versioncmp($release, '15.04') >= 0 {
+      include sunet::systemd_reload
+
+      # replace init.d script with systemd service file to get Restart=always
+      file {
+        '/etc/systemd/system/ntp.service':
+          content => template('sunet/ntp/ntp.service.erb'),
+          notify  => [Class['sunet::systemd_reload'],
+                      Service['ntp'],
+                      ],
+          ;
+      }
     }
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,8 +44,17 @@ class sunet::server (
     }
   }
 
+  $distro = $facts['os']['distro']['id']
+  $release = $facts['os']['distro']['release']['full']
+
   if $ntpd_config {
-    include sunet::ntp
+    # If changing this if-statement you might need to update it in sunet::ntp
+    # as well
+    if ($distro == 'Ubuntu' and versioncmp($release, '22.04') <= 0) or ($distro == 'Debian' and versioncmp($release, '11') <= 0) {
+      include sunet::ntp
+    } else {
+      include sunet::chrony
+    }
   }
 
   if $scriptherder {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -44,16 +44,11 @@ class sunet::server (
     }
   }
 
-  $distro = $facts['os']['distro']['id']
-  $release = $facts['os']['distro']['release']['major']
-
   if $ntpd_config {
-    # If changing this if-statement you might need to update it in sunet::ntp
-    # as well
-    if ($distro == 'Ubuntu' and versioncmp($release, '22.04') <= 0) or ($distro == 'Debian' and versioncmp($release, '11') <= 0) {
-      include sunet::ntp
-    } else {
+    if $::facts['sunet_chrony_enabled'] == 'yes' {
       include sunet::chrony
+    } else {
+      include sunet::ntp
     }
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,7 +45,7 @@ class sunet::server (
   }
 
   $distro = $facts['os']['distro']['id']
-  $release = $facts['os']['distro']['release']['full']
+  $release = $facts['os']['distro']['release']['major']
 
   if $ntpd_config {
     # If changing this if-statement you might need to update it in sunet::ntp


### PR DESCRIPTION
This affects Ubuntu 23.04 and up as well as Debian 12 and up.

It is unfortunate that we need to modify sunet::ntp as well, but the problem is that ops-repos sometimes pull in sunet::ntp by hand (sometimes to set specific configuration in cosmos-rules etc) so in those cases it is hard to do a clean cutover between them.

For that reason sunet::ntp now does nothing on hosts matching the same criteria as the ones where sunet::server applies sunet::chrony. This way both can be applied to a host at the same time.