### PR TITLE
Enable account linking again

### DIFF
--- a/templates/mastodon/web/mastodon.env.erb
+++ b/templates/mastodon/web/mastodon.env.erb
@@ -43,5 +43,14 @@ SAML_ATTRIBUTES_STATEMENTS_EMAIL=urn:oid:0.9.2342.19200300.100.1.3
 SAML_ATTRIBUTES_STATEMENTS_FIRST_NAME=urn:oid:2.5.4.42
 SAML_ATTRIBUTES_STATEMENTS_LAST_NAME=urn:oid:2.5.4.4
 SAML_UID_ATTRIBUTE=urn:oasis:names:tc:SAML:attribute:subject-id
+# In 4.2.6 a safety feature regarding account linking was introduced.
+# This causes trouble for users in our instance which had created their
+# account manually but never signed in throught SSO. They could no longer
+# access their account if they logged out or the session was interupted.
+# Our setup relays on account linking in order to allow users the
+# possibilty to pick username during registration.
+# https://github.com/mastodon/mastodon/releases/tag/v4.2.6
+# https://github.com/mastodon/mastodon/security/advisories/GHSA-vm39-j3vx-pch3
+ALLOW_UNSAFE_AUTH_PROVIDER_REATTACH=true
 # Based on the Scopes found in the metadata in SWAMID. Feel free to add domains if needed
 EMAIL_DOMAIN_ALLOWLIST=antagning.se|bth.se|chalmers.se|du.se|eduid.se|ehs.se|esh.se|fhs.se|formas.se|forte.se|gih.se|gu.se|hb.se|hh.se|hhs.se|hig.se|his.se|hj.se|hkr.se|hv.se|oru.se|irf.se|kau.se|kb.se|ki.se|kkh.se|klimatpolitiskaradet.se|kmh.se|konstfack.se|kth.se|kva.se|liu.se|lnu.se|ltu.se|lu.se|mah.se|mau.se|mchs.se|mdh.se|miun.se|nordu.net|nrm.se|fhs.se|oru.se|ri.se|rkh.se|shh.se|slu.se|smhi.se|snsa.se|strategiska.se|konstfack.se|uniarts.se|su.se|sunet.se|suni.se|ths.se|uhr.se|uka.se|umu.se|uniarts.se|uu.se|vinnova.se|vr.se|mdu.se


### PR DESCRIPTION
Was disabled in 4.2.6 as stated in the comment