### PR TITLE
puppet8 compatibility

### DIFF
--- a/manifests/ssh_keyscan/host.pp
+++ b/manifests/ssh_keyscan/host.pp
@@ -10,7 +10,7 @@ define sunet::ssh_keyscan::host (
     default => [$address]
   }
   if ($the_address !~ Array) {
-    fail("Variable {$the_address} is not an array")
+    fail("Variable ${the_address} is not an array")
   }
   $the_aliases = concat(any2array($aliases),[$title],[$the_address])
   concat::fragment {"${title}_sunet_keyscan":

--- a/manifests/ssh_keyscan/host.pp
+++ b/manifests/ssh_keyscan/host.pp
@@ -9,7 +9,7 @@ define sunet::ssh_keyscan::host (
     undef   => dns_lookup($title),
     default => [$address]
   }
-  unless ($the_address =~ Array) {
+  if ($the_address !~ Array) {
     fail("Variable $the_address is not an array")
   }
   $the_aliases = concat(any2array($aliases),[$title],[$the_address])

--- a/manifests/ssh_keyscan/host.pp
+++ b/manifests/ssh_keyscan/host.pp
@@ -10,7 +10,7 @@ define sunet::ssh_keyscan::host (
     default => [$address]
   }
   if ($the_address !~ Array) {
-    fail("Variable $the_address is not an array")
+    fail("Variable {$the_address} is not an array")
   }
   $the_aliases = concat(any2array($aliases),[$title],[$the_address])
   concat::fragment {"${title}_sunet_keyscan":

--- a/manifests/ssh_keyscan/host.pp
+++ b/manifests/ssh_keyscan/host.pp
@@ -9,7 +9,9 @@ define sunet::ssh_keyscan::host (
     undef   => dns_lookup($title),
     default => [$address]
   }
-  validate_array($the_address)
+  unless ($the_address =~ Array) {
+    fail("Variable $the_address is not an array")
+  }
   $the_aliases = concat(any2array($aliases),[$title],[$the_address])
   concat::fragment {"${title}_sunet_keyscan":
     target  => $hostsfile,


### PR DESCRIPTION
Function `validate_array` has been deprecated for a long time and removed from puppet8 (default in ubuntu24).

Validate array does:
https://forge.puppetlabs.com/modules/puppetlabs/stdlib/6.0.0/readme#validate_array
> Validates that all passed values are array data structures. Terminates catalog compilation if any value fails this check.

So to replicate that i used the `fail()` function:
> Fail with a parse error. Any parameters will be stringified, concatenated, and passed to the exception-handler.
https://www.puppet.com/docs/puppet/7/function.html#fail

Similar solutions for validating arrays done here:
https://github.com/SUNET/puppet-sunet/blob/780273201913a8fb55411e7b2d0160a0ac550446/functions/format_nft_set.pp#L11
https://github.com/SUNET/puppet-sunet/blob/780273201913a8fb55411e7b2d0160a0ac550446/manifests/dehydrated.pp#L22-L25
