### PR TITLE
Make IPv6 SNAT rules match more of ULA range

### DIFF
--- a/templates/dockerhost/200-dockerhost2_nftables.nft.erb
+++ b/templates/dockerhost/200-dockerhost2_nftables.nft.erb
@@ -26,8 +26,8 @@ table ip6 nat {
 #
 add rule ip nat postrouting ip saddr { 172.16.0.0/12 } iifname docker0   counter masquerade comment "SNAT traffic from Docker"
 add rule ip nat postrouting ip saddr { 172.16.0.0/12 } iifname br-*      counter masquerade comment "SNAT traffic from Docker"
-add rule ip6 nat postrouting ip6 saddr { fd0c::/16 }   iifname docker0   counter masquerade comment "SNAT traffic from Docker"
-add rule ip6 nat postrouting ip6 saddr { fd0c::/16 }   iifname br-*      counter masquerade comment "SNAT traffic from Docker"
+add rule ip6 nat postrouting ip6 saddr { fd00::/8 }    iifname docker0   counter masquerade comment "SNAT traffic from Docker"
+add rule ip6 nat postrouting ip6 saddr { fd00::/8 }    iifname br-*      counter masquerade comment "SNAT traffic from Docker"
 
 #
 # Allow forwarding packages from docker


### PR DESCRIPTION
When creating containers via compose using a network with "enable_ipv6: true" the IPv6 network will be selected out of the ULA range: https://docs.docker.com/engine/daemon/ipv6/#dynamic-ipv6-subnet-allocation https://en.wikipedia.org/wiki/Unique_local_address

This means the fd0c::/16 match is not wide enough. As an example I got the address `"Subnet": "fd6b:795b:49eb::/64"` in a lab. Just be prepred to NAT the whole fd00::/8 instead.