### PR TITLE
Change hash algorithm from md5 to sha256, SUNETOPS-1972

### DIFF
--- a/templates/pypi/start_pypiserver.sh.erb
+++ b/templates/pypi/start_pypiserver.sh.erb
@@ -25,5 +25,6 @@ echo "$0: Starting ${run}"
 exec start-stop-daemon --start -c pypi:pypi --exec ${run} -- \
     --fallback-url https://pypi.python.org/simple \
     --log-file "${log_dir}/pypiserver.log" \
+    --hash-algo=sha256 \
     -v -v \
     $packages_dir


### PR DESCRIPTION
This is a requirement for 'uv'.
https://github.com/astral-sh/uv

This change/config is already running on the server since 2024-11-14. So this is to make it persistent.