### PR TITLE
baas2 tbmr improvements

### DIFF
--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -37,8 +37,8 @@ class sunet::baas2(
   Array[String] $backup_dirs = [],
   Array[String] $exclude_list = [],
   Boolean       $install_tbmr=false,
-  String        $tbmr_version='9.5.2.3206-1',
-  String        $tbmr_url='https://s3.sto1.safedc.net/94f5b4f4aa674782b6bc4181943e67f1:tbmr/wab0snk8lrh6l8cjzgnaozm8siw7g7/tbmr_9.5.2.3206-1_amd64.deb',
+  String        $tbmr_version='9.6.3.3418-1',
+  String        $tbmr_url='https://s3.sto1.safedc.net/94f5b4f4aa674782b6bc4181943e67f1:tbmr/wab0snk8lrh6l8cjzgnaozm8siw7g7/tbmr_9.6.3.3418-1_amd64.deb',
 ) {
 
   # MUST be set properly in hiera to continue

--- a/templates/baas2/dsm.sys.erb
+++ b/templates/baas2/dsm.sys.erb
@@ -75,5 +75,5 @@ SERVERNAME SafeDC
 <% if @install_tbmr -%>
 
 * Collect TBMR information before doing the backup
-PRESCHEDULECMD '"/usr/bin/tbmrcfg"'
+PRESCHEDULECMD '"/usr/bin/tbmrcfg" 1> tbmr.log 2>&1 || (exit 0)'
 <% end -%>


### PR DESCRIPTION
- Prevent backups from failing if tbmr `PRESCHEDULEDCMD` fails
  - Recommended in public install guide: https://docs.safespring.com/backup/recovery/linux-recovery/
- Update to new TBMR version as recommended by SafeSpring

Changes tested on `pahol-test1.sunet.se`