### PR TITLE
adding ability to set uptime check values in hiera

### DIFF
--- a/manifests/nagios.pp
+++ b/manifests/nagios.pp
@@ -91,8 +91,9 @@ class sunet::nagios(
   sunet::nagios::nrpe_command {'check_total_procs_lax':
     command_line => "/usr/lib/nagios/plugins/check_procs -k -w ${_procw} -c ${_procc}"
   }
-  sunet::nagios::nrpe_command {'check_uptime':
-    command_line => "/usr/lib/nagios/plugins/check_uptime.py -w ${uptimew} -c ${uptimec}"
+  sunet::nagios::nrpe_check_uptime { 'check_uptime':
+    uptimew =>  $uptimew,
+    uptimec =>  $uptimec,
   }
   sunet::nagios::nrpe_command {'check_reboot':
     command_line => '/usr/lib/nagios/plugins/check_reboot'
@@ -102,16 +103,6 @@ class sunet::nagios(
   }
   sunet::nagios::nrpe_command {'check_mailq':
     command_line => '/usr/lib/nagios/plugins/check_mailq -w 20 -c 100'
-  }
-  file { '/usr/lib/nagios/plugins/check_uptime.pl' :
-      ensure  => 'absent',
-  }
-  file { '/usr/lib/nagios/plugins/check_uptime.py' :
-      ensure  => 'file',
-      mode    => '0751',
-      group   => 'nagios',
-      require => Package['nagios-nrpe-server'],
-      content => template('sunet/nagioshost/check_uptime.py.erb'),
   }
   file { '/usr/lib/nagios/plugins/check_reboot' :
       ensure  => 'file',

--- a/manifests/nagios/nrpe_check_uptime.pp
+++ b/manifests/nagios/nrpe_check_uptime.pp
@@ -1,8 +1,12 @@
 # Check uptime
 define sunet::nagios::nrpe_check_uptime (
-  Integer $uptimew         = 30,
-  Integer $uptimec         = 50,
+  Integer $uptimew = 30,
+  Integer $uptimec = 50,
 ) {
+
+  $_uptimew = lookup('check_uptime_warning', undef, undef, $uptimew)
+  $_uptimec = lookup('check_uptime_critical', undef, undef, $uptimec)
+
   file { '/usr/lib/nagios/plugins/check_uptime.pl' :
       ensure  => 'absent',
   }
@@ -14,6 +18,6 @@ define sunet::nagios::nrpe_check_uptime (
       content => template('sunet/nagioshost/check_uptime.py.erb'),
   }
   sunet::nagios::nrpe_command {'check_uptime':
-    command_line => "/usr/lib/nagios/plugins/check_uptime.py -w ${uptimew} -c ${uptimec}"
+    command_line => "/usr/lib/nagios/plugins/check_uptime.py -w ${_uptimew} -c ${_uptimec}"
   }
 }


### PR DESCRIPTION
Lookup value from hiera, otherwise use set parameters, otherwise use defaults from parameters. Also doing some cleanup and pointing to new class for old class.

Is `check_uptime_warning` and `check_uptime_critical` reasonable names for hiera?