### PR TITLE
Support for dockerhost2

### DIFF
--- a/manifests/metadata/mdqp.pp
+++ b/manifests/metadata/mdqp.pp
@@ -8,11 +8,16 @@ class sunet::metadata::mdqp(
       include sunet::packages::jq
       include sunet::packages::xmlstarlet
 
+      $docker_class = $::facts['dockerhost2'] ? {
+        yes => 'sunet::dockerhost2',
+        default => 'sunet::dockerhost',
+      }
+
       $image_tag = "docker.sunet.se/mdqp:${imagetag}"
       docker::image { $image_tag :  # make it possible to use the same docker image more than once on a node
         ensure  => 'present',
         image   => $image_tag,
-        require => Class['sunet::dockerhost'],
+        require => Class[$docker_class],
       }
 
       file { '/opt/mdqp':


### PR DESCRIPTION
Worth notice is that `dockerhost2` operates without the network namespaces from `dockerhost` so the tooling around mdqp might need to be tweaked. That's nothing this PR can handle since the switch is done in ops-repo.