### PR TITLE
Kano scriptherder cronjob fix

### DIFF
--- a/files/scriptherder/cleanup_scriptherder
+++ b/files/scriptherder/cleanup_scriptherder
@@ -77,7 +77,7 @@ with os.popen("/usr/bin/crontab -l") as pipe:
                 break
 
         # Make sure --name isn't the last argument
-        if position > len(tokens):
+        if position < len(tokens):
             job_name = tokens[position].replace("-", "_")
         else:
             continue

--- a/files/scriptherder/cleanup_scriptherder
+++ b/files/scriptherder/cleanup_scriptherder
@@ -1,7 +1,59 @@
 #!/usr/bin/env python3
 
-import re
 import os
+import re
+
+
+def decide_interval(tokens):
+    # Default to weekly
+    interval = "weekly"
+    if tokens[0][0] == "@":
+        word = tokens[0]
+        if word == "@reboot":
+            # reboot once every half year?
+            interval = "halfyear"
+        elif word == "@yearly" or word == "@annually":
+            interval = "yearly"
+        elif word == "@monthly":
+            interval = "monthly"
+        elif word == "@weekly":
+            interval = "weekly"
+        elif word == "@daily" or word == "@midnight" or word == "@hourly":
+            interval = "daily"
+    else:
+        if tokens[1].startswith('*') and (
+            tokens[2] == tokens[3] == tokens[4] == "*"
+        ):
+            interval = "hourly"
+        elif tokens[2] == tokens[3] == tokens[4] == "*":
+            interval = "daily"
+        elif tokens[3] != "*":
+            interval = "yearly"
+        elif tokens[2] != "*":
+            interval = "monthly"
+        elif tokens[4] != "*":
+            interval = "weekly"
+    return interval
+
+
+def decide_days_to_save(interval):
+    min_logs_to_save = 7
+    if interval == "yearly":
+        days_to_save = min_logs_to_save * 365
+    elif interval == "halfyear":
+        days_to_save = min_logs_to_save * 180
+    elif interval == "monthly":
+        days_to_save = min_logs_to_save * 31
+    elif interval == "weekly":
+        days_to_save = min_logs_to_save * 7
+    elif interval == "daily":
+        days_to_save = min_logs_to_save * 1
+    else:
+        # "hourly" If a job runs more than once per hour,
+        # like "*/5" or even "*" we want to keep even less
+        days_to_save = 2
+    return days_to_save
+
 
 with os.popen("/usr/bin/crontab -l") as pipe:
     for line in pipe:
@@ -16,44 +68,8 @@ with os.popen("/usr/bin/crontab -l") as pipe:
             continue
 
         tokens = line.split()
-        # Default to weekly
-        interval = "weekly"
-        if tokens[0][0] == "@":
-            word = tokens[0]
-            if word == "@reboot":
-                # reboot once every half year?
-                interval = "halfyear"
-            elif word == "@yearly" or word == "@annually":
-                interval = "yearly"
-            elif word == "@monthly":
-                interval = "monthly"
-            elif word == "@weekly":
-                interval = "weekly"
-            elif word == "@daily" or word == "@midnight" or word == "@hourly":
-                interval = "daily"
-        else:
-            if tokens[2] == tokens[3] == tokens[4] == "*":
-                interval = "daily"
-            elif tokens[3] != "*":
-                interval = "yearly"
-            elif tokens[2] != "*":
-                interval = "monthly"
-            elif tokens[4] != "*":
-                interval = "weekly"
-
-        min_logs_to_save = 7
-        if interval == "yearly":
-            days_to_save = min_logs_to_save * 365
-        elif interval == "halfyear":
-            days_to_save = min_logs_to_save * 180
-        elif interval == "monthly":
-            days_to_save = min_logs_to_save * 31
-        elif interval == "weekly":
-            days_to_save = min_logs_to_save * 7
-        else:
-            # "daily":
-            days_to_save = min_logs_to_save * 1
-
+        interval = decide_interval(tokens)
+        days_to_save = decide_days_to_save(interval)
         position = 0
         for arg in tokens:
             position += 1
@@ -70,6 +86,9 @@ with os.popen("/usr/bin/crontab -l") as pipe:
         job_name = tokens[position].replace("-", "_")
 
         if job_name and days_to_save:
+            command = "find /var/cache/scriptherder -type f "
+            command += f"-mtime +{days_to_save} -name {job_name}__* "
+            command += "-delete"
             os.system(
-                f"find /var/cache/scriptherder -type f -mtime +{days_to_save} -name {job_name}__* -print0 | xargs -0 rm -f"
+                command
             )


### PR DESCRIPTION
 Add support for jobs that run more often than hourly
    
I don't now how much logs we should save for these jobs,
but drive has a satosa that runs 109 jobs every five minutes
and run time is above a minute with 14 days, and about 10 seconds
with 2 days, so I decided to hard code that for these types of jobs.
    
It also refactors the code to reduce cyclomatic complexity
adding two functions decide_days_to_save and decide_interval

It also fixes a logical bug