### PR TITLE
Don't use public hostname to resolve certificate file locations

### DIFF
--- a/manifests/docker_registry2.pp
+++ b/manifests/docker_registry2.pp
@@ -1,6 +1,7 @@
 # host docker registry with compose
 class sunet::docker_registry2 (
   String $registry_public_hostname   = 'docker.example.com',
+  String $registry_internal_hostname = 'docker.internal.example.com',
   String $interface                  = 'ens3',
   Array $resolvers                   = [],
   String $registry_tag               = '2',

--- a/templates/docker_registry2/docker-compose-docker-registry.yml.erb
+++ b/templates/docker_registry2/docker-compose-docker-registry.yml.erb
@@ -27,9 +27,9 @@ services:
     ports:
       - "443:443"
     volumes:
-      - "/etc/dehydrated/certs/<%= @registry_public_hostname %>.key:/etc/ssl/private/<%= @registry_public_hostname %>.key:ro"
-      - "/etc/dehydrated/certs/<%= @registry_public_hostname %>.crt:/etc/ssl/certs/<%= @registry_public_hostname %>.crt:ro"
-      - "/etc/dehydrated/certs/<%= @registry_public_hostname %>-chain.crt:/etc/ssl/certs/<%= @registry_public_hostname %>-chain.crt:ro"
+      - "/etc/dehydrated/certs/<%= @registry_internal_hostname %>.key:/etc/ssl/private/<%= @registry_public_hostname %>.key:ro"
+      - "/etc/dehydrated/certs/<%= @registry_internal_hostname %>.crt:/etc/ssl/certs/<%= @registry_public_hostname %>.crt:ro"
+      - "/etc/dehydrated/certs/<%= @registry_internal_hostname %>-chain.crt:/etc/ssl/certs/<%= @registry_public_hostname %>-chain.crt:ro"
       - "/opt/docker-registry/infra-ca.crt:/etc/ssl/certs/<%= @registry_public_hostname %>-client-ca.crt:ro"
     environment:
       - SERVER_NAME=<%= @registry_public_hostname %>


### PR DESCRIPTION
For the test instance both the public and private hostname should be `docker-test.platform.sunet.se`.

For the production instance they should be `docker.platform.sunet.se`, and when it goes live `registry_public_hostname` should be changed to `docker.sunet.se`

The corresponding variable in docker_registry.pp is called "fqdn"