### PR TITLE
fix rsyslog firewall syntax

### DIFF
--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -63,7 +63,6 @@ class sunet::rsyslog(
     if ($udp_port) {
         sunet::misc::ufw_allow { "allow-syslog-udp-${udp_port}":
           from  => $udp_client,
-          ip    => 'any',
           proto => 'udp',
           port  => $udp_port
         }
@@ -72,7 +71,6 @@ class sunet::rsyslog(
     if ($tcp_port) {
         sunet::misc::ufw_allow { "allow-syslog-tcp-${tcp_port}":
           from  => $tcp_client,
-          ip    => 'any',
           proto => 'tcp',
           port  => $tcp_port
         }

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -61,7 +61,7 @@ class sunet::rsyslog(
   if ($tcp_port or $udp_port) {
 
     if ($udp_port) {
-        ufw::allow { "allow-syslog-udp-${udp_port}":
+        sunet::misc::ufw_allow { "allow-syslog-udp-${udp_port}":
           from  => $udp_client,
           ip    => 'any',
           proto => 'udp',
@@ -70,7 +70,7 @@ class sunet::rsyslog(
     }
 
     if ($tcp_port) {
-        ufw::allow { "allow-syslog-tcp-${tcp_port}":
+        sunet::misc::ufw_allow { "allow-syslog-tcp-${tcp_port}":
           from  => $tcp_client,
           ip    => 'any',
           proto => 'tcp',


### PR DESCRIPTION
This is to make the class compatible with modern servers running NFT. 
Using this manifest to make it backwards compatible with legacy servers running UFW:
- https://github.com/SUNET/puppet-sunet/blob/main/manifests/misc/ufw_allow.pp

This was the error encountered on a ubuntu-24 server using this class:
`Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Unknown resource type: 'ufw::allow' (file: /etc/puppet/cosmos-modules/sunet/manifests/rsyslog.pp, line: 64, column: 9) on node log-test-sto3-1.komreg.net`