### PR TITLE
Bump knubbis-fleetlock to v0.0.21 by default

### DIFF
--- a/manifests/knubbis/fleetlock_standalone.pp
+++ b/manifests/knubbis/fleetlock_standalone.pp
@@ -15,7 +15,7 @@
 # @param domain                     The domain where the fleetlock server will supply its services
 # @param letsencrypt_prod           Should the server request real letsencrypt certificates
 class sunet::knubbis::fleetlock_standalone(
-  String  $knubbis_fleetlock_version='v0.0.19',
+  String  $knubbis_fleetlock_version='v0.0.21',
   String  $etcd_version='v3.5.8',
   String  $cfssl_helper_version='v0.0.1',
   String  $etcdctl_helper_version='v0.0.1',


### PR DESCRIPTION
Places mutex around argon2 call to not overwhelm the server with OOM problems if many machines come running at the same time.