### PR TITLE
Init nftables, normaly done in sunet::server

### DIFF
--- a/manifests/pypi.pp
+++ b/manifests/pypi.pp
@@ -109,7 +109,9 @@ class sunet::pypi (
         command => '/usr/bin/openssl dhparam -out /opt/pypi/nginx/dhparam.pem 2048',
         unless  => '/usr/bin/test -s /opt/pypi/nginx/dhparam.pem',
     }
-
+    # init nftables since we run sunet::server (sshd_config: false) that normaly does that
+    notice('Init nftables')
+    ensure_resource ('class','sunet::nftables::init', {})
     # nftables
     sunet::nftables::allow { 'allow-http':
       from => any,


### PR DESCRIPTION
When 'sshd_config: false' is set in sunet::server, nftables is not initiated. So we get this error:
`Error: Could not find resource 'Service[nftables]' in parameter 'notify' (file: /etc/puppet/cosmos-modules/sunet/manifests/dockerhost2.pp, line: 40)`

So the fix is to add it to the pypi class.

This is tested in production and works.