### PR TITLE
Add acme-d support for naemon

### DIFF
--- a/files/naemon_monitor/certbot-acmed-renew-deploy-hook
+++ b/files/naemon_monitor/certbot-acmed-renew-deploy-hook
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/docker exec -it naemon_monitor-thruk-1 service apache2 reload

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -4,7 +4,7 @@
 #
 class sunet::naemon_monitor (
   String $domain,
-  Enum['acme-c','acme-d'] $acme_protocol = 'acme-c'
+  Enum['acme-c','acme-d'] $acme_protocol = 'acme-c',
   Boolean $enable_nocsection = false,
   String $influx_password = lookup('influx_password', String, undef, ''),
   String $naemon_tag = 'latest',

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -4,6 +4,7 @@
 #
 class sunet::naemon_monitor (
   String $domain,
+  Enum['acme-c','acme-d'] $acme_protocol = 'acme-c'
   Boolean $enable_nocsection = false,
   String $influx_password = lookup('influx_password', String, undef, ''),
   String $naemon_tag = 'latest',
@@ -83,7 +84,9 @@ class sunet::naemon_monitor (
     }
   }
 
-  class { 'sunet::dehydrated::client': domain => $domain, ssl_links => true }
+  if $acme_protocol == 'acme-c' {
+    class { 'sunet::dehydrated::client': domain => $domain, ssl_links => true }
+  }
 
   if lookup('shib_key', undef, undef, undef) != undef {
     sunet::snippets::secret_file { '/opt/naemon_monitor/shib-certs/sp-key.pem': hiera_key => 'shib_key' }

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -14,7 +14,7 @@ class sunet::naemon_monitor (
   String $thruk_tag = 'latest',
   Array $thruk_admins = ['placeholder'],
   Array $thruk_users = [],
-  Array[String] $thruk_allow_clients = ['any']
+  Array[String] $thruk_allow_clients = ['any'],
   String $influxdb_tag = '1.8',
   String $histou_tag = 'latest',
   String $nagflux_tag = 'latest',

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -133,7 +133,6 @@ class sunet::naemon_monitor (
   file { '/opt/naemon_monitor/stop-monitor.sh':
     ensure  => absent,
   }
-  #
 
   file { '/etc/logrotate.d/naemon_monitor':
     ensure  => file,
@@ -184,7 +183,7 @@ class sunet::naemon_monitor (
   }
   if $receive_otel {
     # Grafana can only use one group via the apache proxy auth module, so we cheat and make everyone editors
-    # and admins can be manually assigned via gui. 
+    # and admins can be manually assigned via gui.
     $allowed_users_string = join($thruk_admins + $thruk_users,' ')
     $thruk_admins.each |$user| {
       exec { "set-admin for ${user}":

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -14,6 +14,7 @@ class sunet::naemon_monitor (
   String $thruk_tag = 'latest',
   Array $thruk_admins = ['placeholder'],
   Array $thruk_users = [],
+  Array[String] $thruk_allow_clients = ['any']
   String $influxdb_tag = '1.8',
   String $histou_tag = 'latest',
   String $nagflux_tag = 'latest',
@@ -43,12 +44,12 @@ class sunet::naemon_monitor (
   if $::facts['sunet_nftables_enabled'] == 'yes' {
     sunet::nftables::docker_expose { 'allow_http' :
       iif           => $interface,
-      allow_clients => 'any',
+      allow_clients => $thruk_allow_clients,
       port          => 80,
     }
     sunet::nftables::docker_expose { 'allow_https' :
       iif           => $interface,
-      allow_clients => 'any',
+      allow_clients => $thruk_allow_clients,
       port          => 443,
     }
     if $receive_otel {

--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -88,6 +88,15 @@ class sunet::naemon_monitor (
   if $acme_protocol == 'acme-c' {
     class { 'sunet::dehydrated::client': domain => $domain, ssl_links => true }
   }
+  # Add automatic reload of apache on cert renewal for acme-d
+  if $acme_protocol == 'acme-d' {
+    file { '/etc/letsencrypt/renewal-hooks/deploy/certbot-acmed-renew-deploy-hook':
+      ensure  => 'file',
+      mode    => '0755',
+      owner   => 'root',
+      content => file('sunet/naemon_monitor/certbot-acmed-renew-deploy-hook')
+    }
+  }
 
   if lookup('shib_key', undef, undef, undef) != undef {
     sunet::snippets::secret_file { '/opt/naemon_monitor/shib-certs/sp-key.pem': hiera_key => 'shib_key' }

--- a/templates/naemon_monitor/docker-compose.yml.erb
+++ b/templates/naemon_monitor/docker-compose.yml.erb
@@ -48,7 +48,12 @@ services:
     ports:
       - '443:443'
     volumes:
+<% if @acme_protocol == 'acme-c' -%>
       - "/etc/dehydrated/certs/<%= @domain %>:/etc/dehydrated:ro"
+<% end -%>
+<% if @acme_protocol == 'acme-d' -%>
+      - "/etc/letsencrypt/live/<%= @domain %>:/etc/dehydrated:ro"
+<% end -%>
       - '/opt/naemon_monitor/shib-certs:/etc/shibboleth/certs'
       - '/opt/naemon_monitor/data:/var/lib/thruk'
       - '/opt/naemon_monitor/menu_local.conf:/etc/thruk/menu_local.conf'
@@ -129,5 +134,10 @@ services:
       - "4317-4318:4317-4318"
     volumes:
       - "/opt/naemon_monitor/alloy-server.alloy:/etc/alloy/config.alloy:ro"
+<% if @acme_protocol == 'acme-c' -%>
       - "/etc/dehydrated/certs/<%= @domain %>:/etc/dehydrated:ro"
+<% end -%>
+<% if @acme_protocol == 'acme-d' -%>
+      - "/etc/letsencrypt/live/<%= @domain %>:/etc/dehydrated:ro"
+<% end -%>
 <% end -%>

--- a/templates/naemon_monitor/docker-compose.yml.erb
+++ b/templates/naemon_monitor/docker-compose.yml.erb
@@ -55,6 +55,7 @@ services:
 <% end -%>
 <% if @acme_protocol == 'acme-d' -%>
       - "/etc/letsencrypt/live/<%= @domain %>:/etc/dehydrated:ro"
+      - "/etc/letsencrypt/archive/<%= @domain %>/:/archive/<%= @domain %>:ro"
 <% end -%>
       - '/opt/naemon_monitor/shib-certs:/etc/shibboleth/certs'
       - '/opt/naemon_monitor/data:/var/lib/thruk'

--- a/templates/naemon_monitor/docker-compose.yml.erb
+++ b/templates/naemon_monitor/docker-compose.yml.erb
@@ -1,6 +1,7 @@
 version: '3.2'
 
 services:
+<% if @acme_protocol == 'acme-c' -%>
   always-https:
     image: docker.sunet.se/always-https
 <% unless @resolvers.empty? -%>
@@ -13,6 +14,7 @@ services:
       - '80:80'
     environment:
       - 'ACME_URL=http://acme-c.sunet.se/'
+<% end -%>
 
   naemon:
     init: true


### PR DESCRIPTION
This PR adds support for running naemon/thruk with acme-d (in addition to acme-c that is default).

The use case for this is to allow for a server to not have to expose web ports towards the internet just for the sake of acme challenges on cert renewal.

In addition to this, the ability to configure nftables to allow only trusted network prefixes as source has been added to the class.

This feature branch is tested on a new deploy'ed server running acme-d, as well as an older one running acme-c.
No diff was detected on the older instance (as expected).