### PR TITLE
Only keep one day of forge backups locally

### DIFF
--- a/templates/forgejo/backup.erb.sh
+++ b/templates/forgejo/backup.erb.sh
@@ -19,7 +19,7 @@ else
   second_status=${?}
   if [[ ${second_status} -eq 0 ]]; then
     echo "Cleaning up old backups: $(date)"
-    find "${backup_dir}" -mtime +10 -delete
+    find "${backup_dir}" -mtime +1 -delete
   else
     echo "Backup to remote failed: $(date)"
   fi


### PR DESCRIPTION
We don't always have enough disk space for 10 days and there is no need to keep more backups locally.