### PR TITLE
naemon manual hosts

### DIFF
--- a/manifests/naemon_monitor.pp
+++ b/manifests/naemon_monitor.pp
@@ -496,7 +496,7 @@ class sunet::naemon_monitor (
       manage_service      => false,
       cfgdir              => '/etc/naemon/conf.d/nagioscfg',
       host_template       => 'naemon-host',
-      hostgroups           => [],
+      hostgroups          => [],
       service             => 'sunet-naemon_monitor',
       single_ip           => true,
       require             => File['/etc/naemon/conf.d/nagioscfg/'],


### PR DESCRIPTION
With this PR i have added the possibility to opt-out from automatically creating hosts for all servers in the ops-repo that the naemon server belongs to. The use case that lead to this was that we had the need to monitor a Windows environment that is not managed by puppet and hence does not belong to an ops-repo.

This change is tested on a monitor server that does not use this opt-out setting to confirm this change had no effect.