### PR TITLE
Disallow web crawlers on forgejo hosts

### DIFF
--- a/templates/forgejo/nginx.tmpl
+++ b/templates/forgejo/nginx.tmpl
@@ -498,6 +498,10 @@ server {
     include /etc/nginx/vhost.d/default;
     {{- end }}
 
+    location = /robots.txt {
+        add_header Content-Type text/plain;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
     {{- range $path, $containers := $paths }}
         {{- /*
              * Get the VIRTUAL_PROTO defined by containers w/ the same


### PR DESCRIPTION
AI companies periodically fetch .tar.gz and .bundle files of all repositores. These files are cached on the server and use several Gbs of disk space, and the usage is duplicated with each backup.