### PR TITLE
Trigger reboot based on uptime

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,7 +45,7 @@ class sunet::server (
     }
   }
 
-  if $trigger_reboot and os.path.exists('/etc/cosmos-automatic-reboot') {
+  if $trigger_reboot and find_file('/etc/cosmos-automatic-reboot') {
     if $facts['system_uptime']['days'] > $trigger_reboot {
       file { '/var/run/reboot-required':
         ensure => present,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,6 +15,7 @@ class sunet::server (
   Boolean $disable_all_local_users = false,
   Array $mgmt_addresses = [lookup('mgmt_addresses', undef, undef, [])],
   Boolean $ssh_allow_from_anywhere = false,
+  Variant[Integer, Undef] $trigger_reboot = undef,
 ) {
   if $fail2ban {
     # Configure fail2ban to lock out SSH scanners
@@ -41,6 +42,14 @@ class sunet::server (
       mgmt_addresses      => flatten($mgmt_addresses),
       nftables_init       => $nftables_init,
       port                => pick($ssh_port, 22),
+    }
+  }
+
+  if $trigger_reboot and os.path.exists('/etc/cosmos-automatic-reboot') {
+    if $facts['system_uptime']['days'] > $trigger_reboot {
+      file { '/var/run/reboot-required':
+        ensure => present,
+      }
     }
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,7 +15,7 @@ class sunet::server (
   Boolean $disable_all_local_users = false,
   Array $mgmt_addresses = [lookup('mgmt_addresses', undef, undef, [])],
   Boolean $ssh_allow_from_anywhere = false,
-  Variant[Integer, Undef] $trigger_reboot = undef,
+  Variant[Integer, Undef] $reboot_trigger = undef,
 ) {
   if $fail2ban {
     # Configure fail2ban to lock out SSH scanners
@@ -45,8 +45,8 @@ class sunet::server (
     }
   }
 
-  if $trigger_reboot and find_file('/etc/cosmos-automatic-reboot') {
-    if $facts['system_uptime']['days'] > $trigger_reboot {
+  if $reboot_trigger and find_file('/etc/cosmos-automatic-reboot') {
+    if $facts['system_uptime']['days'] > $reboot_trigger {
       file { '/var/run/reboot-required':
         ensure => present,
       }


### PR DESCRIPTION
We want to reboot our machines once in a while. Most of the time the kernel update cycle is enough to trigger a reboot.
Sometimes the kernel is secure enough so no updates appears for a long time but we still want to reboot on a regular basis.