### PR TITLE
Pahol otel opt-out

### DIFF
--- a/manifests/otel/alloy.pp
+++ b/manifests/otel/alloy.pp
@@ -1,55 +1,59 @@
 # @summary class to setup Grafana Alloy
-# @param otel_receiver Where should we send OpenTelemetry data?
+# @param otel_receiver   Where should we send OpenTelemetry data?
+# @param enabled         Possibility to opt out from sending otel data (if you for example enable it globally in a repo)
 class sunet::otel::alloy (
-  String $otel_receiver    = undef,
+  String  $otel_receiver    = undef,
+  Boolean $enabled=true,
 ) {
 
-  ensure_resource('sunet::apt::repo_grafana', 'sunet-otel-alloy-grafana-repo')
+  if $enabled {
+    ensure_resource('sunet::apt::repo_grafana', 'sunet-otel-alloy-grafana-repo')
 
-  exec { 'alloy_update':
-    command => 'apt update',
-    unless  => 'dpkg -l alloy',
-  }
-  package { 'alloy':
-    ensure => 'installed',
-  }
-  file { '/etc/alloy' :
-    ensure => 'directory',
-    notify => Service['alloy'],
-    mode   => '0644',
-    group  => 'root',
-  }
-  file { '/etc/alloy/targets.d' :
-    ensure => 'directory',
-    notify => Service['alloy'],
-    mode   => '0644',
-    group  => 'root',
-  }
-  file { '/etc/alloy/targets.d/example.yaml' :
-    ensure  => 'file',
-    notify  => Service['alloy'],
-    mode    => '0644',
-    group   => 'root',
-    content => template( 'sunet/otel/example.yaml' ),
-  }
-  file { '/etc/alloy/config.alloy' :
-    ensure  => 'file',
-    notify  => Service['alloy'],
-    mode    => '0644',
-    group   => 'root',
-    content => template( 'sunet/otel/config.alloy' ),
-  }
-  service { 'alloy':
-    ensure  => 'running',
-    enable  => 'true',
-    require => Package['alloy'],
-  }
-  sunet::nftables::docker_expose { 'allow_local_opentelemetry_grpc' :
-    allow_clients => '172.16.0.0/12',
-    port          => '4317',
-  }
-  sunet::nftables::docker_expose { 'allow_local_opentelemetry_http' :
-    allow_clients => '172.16.0.0/12',
-    port          => '4318',
+    exec { 'alloy_update':
+      command => 'apt update',
+      unless  => 'dpkg -l alloy',
+    }
+    package { 'alloy':
+      ensure => 'installed',
+    }
+    file { '/etc/alloy' :
+      ensure => 'directory',
+      notify => Service['alloy'],
+      mode   => '0644',
+      group  => 'root',
+    }
+    file { '/etc/alloy/targets.d' :
+      ensure => 'directory',
+      notify => Service['alloy'],
+      mode   => '0644',
+      group  => 'root',
+    }
+    file { '/etc/alloy/targets.d/example.yaml' :
+      ensure  => 'file',
+      notify  => Service['alloy'],
+      mode    => '0644',
+      group   => 'root',
+      content => template( 'sunet/otel/example.yaml' ),
+    }
+    file { '/etc/alloy/config.alloy' :
+      ensure  => 'file',
+      notify  => Service['alloy'],
+      mode    => '0644',
+      group   => 'root',
+      content => template( 'sunet/otel/config.alloy' ),
+    }
+    service { 'alloy':
+      ensure  => 'running',
+      enable  => 'true',
+      require => Package['alloy'],
+    }
+    sunet::nftables::docker_expose { 'allow_local_opentelemetry_grpc' :
+      allow_clients => '172.16.0.0/12',
+      port          => '4317',
+    }
+    sunet::nftables::docker_expose { 'allow_local_opentelemetry_http' :
+      allow_clients => '172.16.0.0/12',
+      port          => '4318',
+    }
   }
 }

--- a/templates/otel/config.alloy
+++ b/templates/otel/config.alloy
@@ -13,7 +13,7 @@ otelcol.receiver.otlp "otel" {
     traces  = [otelcol.processor.batch.otel.input]
   }
 }
-// Batch send eveything to the default exporter below. 
+// Batch send eveything to the default exporter below.
 otelcol.processor.batch "otel" {
   output {
     metrics = [otelcol.exporter.otlp.default.input]
@@ -101,7 +101,7 @@ otelcol.receiver.prometheus "default" {
   }
 }
 // change name of job to node
-discovery.relabel "node_exporter" { 
+discovery.relabel "node_exporter" {
     // workaround that the job name get set to 'integrations/unix' instead of 'node' that the dashboard expects
   targets = prometheus.exporter.unix.default.targets
   rule {
@@ -113,7 +113,7 @@ discovery.relabel "node_exporter" {
 discovery.file "targetsd" {
   files = ["/etc/alloy/targets.d/*.yaml"]
 }
-// scrape our own metrics 
+// scrape our own metrics
 prometheus.scrape "default" {
   targets = discovery.relabel.node_exporter.output
   forward_to = [
@@ -126,7 +126,7 @@ prometheus.scrape "targetsd" {
     otelcol.receiver.prometheus.default.receiver,
   ]
 }
-// Write everything to the receiver below. 
+// Write everything to the receiver below.
 otelcol.exporter.otlp "default" {
   client {
     endpoint = "<%= @otel_receiver %>:4317"


### PR DESCRIPTION
Add option to opt-out from configuring alloy. 

This can be useful if you need to exclude one server from sending telemetry after enabling it globally on a repo. For example the monitoring server since it uses the same alloy ports on the container as the installed alloy package causing a container reboot loop.