### PR TITLE
Bump tsm version to 8.1.27

### DIFF
--- a/manifests/baas2.pp
+++ b/manifests/baas2.pp
@@ -33,7 +33,7 @@ class sunet::baas2(
   String        $nodename='',
   String        $tcpserveraddress='server2.backup.dco1.safedc.net',
   Boolean       $monitor_backups=true,
-  String        $version='8.1.22.0',
+  String        $version='8.1.27.0',
   Array[String] $backup_dirs = [],
   Array[String] $exclude_list = [],
   Boolean       $install_tbmr=false,


### PR DESCRIPTION
Bump TSM client version to 8.1.27 to get latest bug and security fixes. 
https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=new-backup-archive-client-updates