### PR TITLE
Allow kubectl top node to talk to self.

### DIFF
--- a/templates/microk8s/500-microk8s-rules.nft.erb
+++ b/templates/microk8s/500-microk8s-rules.nft.erb
@@ -1,4 +1,5 @@
 add rule inet filter input iifname "vxlan.calico" counter accept
+add rule inet filter input iifname "cali*" counter accept comment "Allow in-cluster trafic to talk to this host, needed for kubectl top node"
 add rule inet filter forward iifname "vxlan.calico" counter accept
 add rule inet filter forward iifname "cali*" counter accept
 add rule inet filter forward oifname "cali*" counter accept


### PR DESCRIPTION
Without this change `kubectl top node` is unable to show data for the host running the in cluster kubernetes metric-server.
Trafic that is dropped looks like: 
`input_drop: IN=cali0e024e4dcc8 OUT= MACSRC=96:4e:79:bd:71:a5 MACDST=ee:ee:ee:ee:ee:ee MACPROTO=0800 SRC=10.1.13.196 DST=89.46.20.64 LEN=60 TOS=0x00 PREC=0x00 TTL=64 ID=43109 DF PROTO=TCP SPT=33354 DPT=10250 SEQ=2244955216 ACK=0 WINDOW=64860 RES=0x00 SYN URGP=0 OPT (020405820402080AB771426E0000000001030307) MARK=0x40000 `