### PR TITLE
Update chrony config for Debian 13

### DIFF
--- a/manifests/chrony.pp
+++ b/manifests/chrony.pp
@@ -23,6 +23,15 @@ class sunet::chrony(
   Array[String] $ntsserverkeys = [],
 ) {
 
+  $distro = $facts['os']['distro']['id']
+  $release = $facts['os']['distro']['release']['major']
+
+  if $distro == 'Ubuntu' or ($distro == 'Debian' and versioncmp($release, '12') <= 0) {
+    $use_leapseclist = false
+  } else {
+    $use_leapseclist = true
+  }
+
   ### BEGIN sunet::ntp cleanup
   # Cleanup potential remains from previous usage of sunet::ntp
   package { 'ntp': ensure => 'purged' }

--- a/templates/chrony/chrony.conf.erb
+++ b/templates/chrony/chrony.conf.erb
@@ -3,9 +3,6 @@
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
 # information about usable directives.
 
-# Include configuration files found in /etc/chrony/conf.d.
-confdir /etc/chrony/conf.d
-
 <% if @dhcp_time_sources -%>
 # Use time sources from DHCP.
 sourcedir /run/chrony-dhcp
@@ -14,11 +11,11 @@ sourcedir /run/chrony-dhcp
 # Use NTP sources found in /etc/chrony/sources.d.
 sourcedir /etc/chrony/sources.d
 
-# This directive specify the location of the file containing ID/key pairs for
+# This directive specifies the location of the file containing ID/key pairs for
 # NTP authentication.
 keyfile /etc/chrony/chrony.keys
 
-# This directive specify the file into which chronyd will store the rate
+# This directive specifies the file into which chronyd will store the rate
 # information.
 driftfile /var/lib/chrony/chrony.drift
 
@@ -45,7 +42,11 @@ makestep 1 3
 # Get TAI-UTC offset and leap seconds from the system tz database.
 # This directive must be commented out when using time sources serving
 # leap-smeared time.
+<% if @use_leapseclist -%>
+leapseclist /usr/share/zoneinfo/leap-seconds.list
+<% else -%>
 leapsectz right/UTC
+<% end -%>
 
 <% if !@allow_list.empty? -%>
 # The allow directive configures chrony to open an NTP server port and allow
@@ -70,3 +71,6 @@ ntsserverkey <%= ntsserverkey %>
 # The port to listen for run-time monitoring commands. 0 means no port is
 # opened but local chronyc access is still possible through unix socket.
 cmdport <%= @cmdport %>
+
+# Include configuration files found in /etc/chrony/conf.d.
+confdir /etc/chrony/conf.d


### PR DESCRIPTION
On Debian 13 the default chrony config has been modified to use leapseclist instead of leapsectz so lets do that for our Debian 13 machines as well. Once we start seeing Ubuntu machines using leapseclist we can add a version check for Ubuntu as well.

Also Debian 13 has moved the confdir directive to the end of the config to fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1073865 and this feels like something we can do on both old and new machines.

Finally fix comment wording based on Debian 13 config so the diff is smaller on modern machines.