### PR TITLE
Change nftables fw opening syntax

### DIFF
--- a/manifests/otel/alloy.pp
+++ b/manifests/otel/alloy.pp
@@ -47,13 +47,13 @@ class sunet::otel::alloy (
       enable  => 'true',
       require => Package['alloy'],
     }
-    sunet::nftables::docker_expose { 'allow_local_opentelemetry_grpc' :
-      allow_clients => '172.16.0.0/12',
-      port          => '4317',
+    sunet::nftables::allow { 'allow_local_opentelemetry_grpc':
+      from => '172.16.0.0/12',
+      port => '4317',
     }
-    sunet::nftables::docker_expose { 'allow_local_opentelemetry_http' :
-      allow_clients => '172.16.0.0/12',
-      port          => '4318',
+    sunet::nftables::allow { 'allow_local_opentelemetry_http':
+      from => '172.16.0.0/12',
+      port => '4318',
     }
   }
 }


### PR DESCRIPTION
Since the alloy client is not docker based, we can use the `sunet::nftables::allow` syntax instead. Otherwise we get this error on modern servers not running docker:

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Unknown function: 'has_key'. (file: /etc/puppet/cosmos-modules/sunet/manifests/nftables/docker_expose.pp, line: 36, column: 10) (file:
/etc/puppet/cosmos-modules/sunet/manifests/otel/alloy.pp, line: 50) on node X
```