### PR TITLE
nagios users needs sudo to execute the script.

### DIFF
--- a/files/django-ca/nrpe-djangoca.cfg
+++ b/files/django-ca/nrpe-djangoca.cfg
@@ -1,4 +1,4 @@
 # This file is managed by puppet
 
 # check-djangoca-status
-command[check-djangoca-status]=/usr/local/sbin/check-djangoca-status
+command[check-djangoca-status]=sudo /usr/local/sbin/check-djangoca-status

--- a/files/django-ca/sudoers-djangoca
+++ b/files/django-ca/sudoers-djangoca
@@ -1,0 +1,2 @@
+# Allow nagios user to sudo when executing check-djangoca-status
+nagios   ALL = NOPASSWD:/usr/local/sbin/check-djangoca-status

--- a/manifests/django_ca/server.pp
+++ b/manifests/django_ca/server.pp
@@ -119,6 +119,13 @@ class sunet::django_ca::server (
     owner   => 'root',
     content => file('sunet/django-ca/nrpe-djangoca.cfg')
   }
+  # sudo exceptions
+  file { '/etc/sudoers.d/sudoers-djangoca':
+    ensure  => 'file',
+    mode    => '0440',
+    owner   => 'root',
+    content => file('sunet/django-ca/sudoers-djangoca')
+  }
   # Custom monitoring scripts
   file { '/usr/local/sbin/check-djangoca-status':
     ensure  => 'file',


### PR DESCRIPTION
nagios user needs to sudo to execute the script
```
runuser -u nagios -- '/usr/local/sbin/check-djangoca-status' WARNING: Unexpected output:
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```