### PR TITLE
Allow access to grub boot menu

### DIFF
--- a/files/server/99-sunet-grub-menu.cfg
+++ b/files/server/99-sunet-grub-menu.cfg
@@ -1,0 +1,6 @@
+# Allow us to access grup during boot.
+# E.g for rescue with single-user mode
+GRUB_TIMEOUT=5
+
+# A menu is always nice and accessible
+GRUB_TIMEOUT_STYLE=menu

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -101,4 +101,16 @@ class sunet::server (
   if $facts['dmi']['product']['name'] =~ /OpenStack\s(Compute|Nova)/ {
     class { 'sunet::iaas::server': }
   }
+
+  file { '/etc/default/grub.d/99-sunet-grub-menu.cfg':
+    ensure  => present,
+    content => file('sunet/server/99-sunet-grub-menu.cfg'),
+    notify  => Exec['sunet_server_update_grub'],
+
+  }
+  exec { 'sunet_server_update_grub':
+    command     => '/usr/sbin/update-grub',
+    refreshonly => true,
+  }
+
 }


### PR DESCRIPTION
Default in the cloud images is to disable grub with `GRUB_TIMEOUT=0`. This is no good when needing to single user boot a machine in need.

Solution tested on
* Debian 11
* Debian 13
* Ubuntu 22
* Ubuntu 24

Test executed in IAAS but I see no risk or problem applying this configuration to all our servers.
