### PR TITLE
Argus server provisioning from puppet-sunet

### DIFF
--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -48,7 +48,7 @@ class sunet::argus::server (
     }
 
     if $argus_clients != '' {
-        $argus_allow_networks = hiera_array($argus_clients,[])
+        $argus_allow_networks = lookup($argus_clients, undef, undef, [])
         $argus_interface = safe_hiera('argus_interface',$facts['interface_default'])
         sunet::nftables::docker_expose { 'allow_https' :
             allow_clients   => $argus_allow_networks,

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -2,10 +2,12 @@
 # @param docker_image    Specific Argus image
 # @param docker_tag      Specific Argus image tag
 # @param url             Specific hostname where Argus will be running
+# @param argus_clients   Hiera Variable that contains list of prefixes allowed to reach Argus
 class sunet::argus::server (
-  String  $docker_image = "docker.sunet.se/sunet/argus-api",
-  String  $docker_tag   = "v2.5.0_sunetbuild",
-  String  $url          = $facts['networking']['hostname']
+  String  $docker_image     = "docker.sunet.se/sunet/argus-api",
+  String  $docker_tag       = "v2.5.0_sunetbuild",
+  String  $url              = $facts['networking']['hostname'],
+  String  $argus_clients    = ''
 ){
 
     $argus_config_dir = '/opt/argus_config'
@@ -25,7 +27,7 @@ class sunet::argus::server (
         ensure  => file,
         group   => 'root',
         mode    => '0755',
-        content => template('argus/localsettings.py.erb'),
+        content => template('sunet/argus/localsettings.py.erb'),
         require => File[$argus_config_dir]
     }
 
@@ -33,7 +35,7 @@ class sunet::argus::server (
         ensure  => file,
         group   => 'root',
         mode    => '0755',
-        content => template('argus/default.conf.erb'),
+        content => template('sunet/argus/default.conf.erb'),
         require => File[$nginx_config_dir]
     }
 
@@ -42,7 +44,19 @@ class sunet::argus::server (
         description      => 'Argus Alarm Aggregator for SUNET CNaaS',
         compose_filename => 'docker-compose.yml',
         compose_dir      => '/opt',
-        content          => template('argus/docker-compose.yml.erb'),
+        content          => template('sunet/argus/docker-compose.yml.erb'),
+    }
+
+    if $argus_clients != '' {
+        $argus_allow_networks = hiera_array($argus_clients,[])
+        $argus_interface = safe_hiera('argus_interface',$facts['interface_default'])
+        sunet::nftables::docker_expose { 'allow_https' :
+            allow_clients   => $argus_allow_networks,
+            port            => '443',
+            iif             => $argus_interface,
+        }
+    } else  {
+        warning('No configured Client IPs for argus. Not allowing HTTPS access for anyone.')
     }
 
 }

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -1,0 +1,48 @@
+# @summary class to Argus Server
+# @param docker_image    Specific Argus image
+# @param docker_tag      Specific Argus image tag
+# @param url             Specific hostname where Argus will be running
+class sunet::argus::server (
+  String  $docker_image = "docker.sunet.se/sunet/argus-api",
+  String  $docker_tag   = "v2.5.0_sunetbuild",
+  String  $url          = $facts['networking']['hostname']
+){
+
+    $argus_config_dir = '/opt/argus_config'
+    $nginx_config_dir = '/opt/nginx_etc/conf.d'
+
+    file { $argus_config_dir:
+        ensure => directory,
+        mode   => '0755'
+    }
+
+    file { $nginx_config_dir:
+        ensure => directory,
+        mode   => '0755'
+    }
+
+    file { '/opt/argus_config/localsettings.py':
+        ensure  => file,
+        group   => 'root',
+        mode    => '0755',
+        content => template('argus/localsettings.py.erb'),
+        require => File[$argus_config_dir]
+    }
+
+    file { '/opt/nginx_etc/conf.d/default.conf':
+        ensure  => file,
+        group   => 'root',
+        mode    => '0755',
+        content => template('argus/default.conf.erb'),
+        require => File[$nginx_config_dir]
+    }
+
+    sunet::docker_compose {'argus_docker_compose':
+        service_name     => 'argus',
+        description      => 'Argus Alarm Aggregator for SUNET CNaaS',
+        compose_filename => 'docker-compose.yml',
+        compose_dir      => '/opt',
+        content          => template('argus/docker-compose.yml.erb'),
+    }
+
+}

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -25,10 +25,10 @@
 #
 #####
 class sunet::argus::server (
-  String  $docker_image     = "docker.sunet.se/sunet/argus-api",
-  String  $docker_tag       = "v2.5.0_sunetbuild",
+  String  $docker_image     = 'docker.sunet.se/sunet/argus-api',
+  String  $docker_tag       = 'v2.5.0_sunetbuild',
   String  $url              = $facts['networking']['hostname'],
-  String  $argus_auth_type   = 'local',
+  String  $argus_auth_type  = 'local',
   Boolean $argus_debug      = false,
   String  $argus_clients    = ''
 ){
@@ -74,9 +74,9 @@ class sunet::argus::server (
         $argus_allow_networks = lookup($argus_clients, undef, undef, [])
         $argus_interface = safe_hiera('argus_interface',$facts['interface_default'])
         sunet::nftables::docker_expose { 'allow_https' :
-            allow_clients   => $argus_allow_networks,
-            port            => '443',
-            iif             => $argus_interface,
+          allow_clients   => $argus_allow_networks,
+          port            => '443',
+          iif             => $argus_interface,
         }
     } else  {
         warning('No configured Client IPs for argus. Not allowing HTTPS access for anyone.')

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -7,6 +7,8 @@ class sunet::argus::server (
   String  $docker_image     = "docker.sunet.se/sunet/argus-api",
   String  $docker_tag       = "v2.5.0_sunetbuild",
   String  $url              = $facts['networking']['hostname'],
+  Boolean $argus_sso        = False,
+  String  $argus_sso_type   = '',
   String  $argus_clients    = ''
 ){
 

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -1,14 +1,34 @@
 # @summary class to Argus Server
-# @param docker_image    Specific Argus image
-# @param docker_tag      Specific Argus image tag
-# @param url             Specific hostname where Argus will be running
-# @param argus_clients   Hiera Variable that contains list of prefixes allowed to reach Argus
+# @param docker_image     Specific Argus image
+# @param docker_tag       Specific Argus image tag
+# @param url              Specific url where Argus will be running
+# @param argus_clients    Hiera Variable that contains list of prefixes allowed to reach Argus
+# @param argus_debug      Boolean variable to enable DJANGO debug on the server.
+# @param argus_auth_type  Boolean variable to enable one type of SSO inlogging local or keycloak.
+#
+# Hiera variables to define on the target host:
+# argus_email_host
+# argus_email_user
+# argus_email_from
+# argus_sms_gateway
+# django_secret_key
+# argus_db_password
+# argus_clients - (ex: argus_front_clients:  [ 10.1.11.0/24, 10.1.0.0/24 ] )
+#
+# If auth type keycloak is selected then:
+# argus_sso_keycloak hashmap with
+#   auth_keycloak_public_key (from https://norpan-keycloak1.cnaas.sunet.se/realms/norpan)
+#   auth_keycloak_key (client-id)
+#   auth_keycloak_secret (client secret)
+#   auth_keycloak_base_url (https://<url>/realms/<realm>)
+#   kc_idp_hint (idp hint towards swamid SAML flow if present)
+#
+#####
 class sunet::argus::server (
   String  $docker_image     = "docker.sunet.se/sunet/argus-api",
   String  $docker_tag       = "v2.5.0_sunetbuild",
   String  $url              = $facts['networking']['hostname'],
-  Boolean $argus_sso        = false,
-  String  $argus_sso_type   = '',
+  String  $argus_auth_type   = 'local',
   Boolean $argus_debug      = false,
   String  $argus_clients    = ''
 ){

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -7,9 +7,9 @@ class sunet::argus::server (
   String  $docker_image     = "docker.sunet.se/sunet/argus-api",
   String  $docker_tag       = "v2.5.0_sunetbuild",
   String  $url              = $facts['networking']['hostname'],
-  Boolean $argus_sso        = False,
+  Boolean $argus_sso        = false,
   String  $argus_sso_type   = '',
-  Boolean $argus_debug      = False,
+  Boolean $argus_debug      = false,
   String  $argus_clients    = ''
 ){
 

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -9,6 +9,7 @@ class sunet::argus::server (
   String  $url              = $facts['networking']['hostname'],
   Boolean $argus_sso        = False,
   String  $argus_sso_type   = '',
+  Boolean $argus_debug      = False,
   String  $argus_clients    = ''
 ){
 

--- a/manifests/argus/server.pp
+++ b/manifests/argus/server.pp
@@ -74,9 +74,9 @@ class sunet::argus::server (
         $argus_allow_networks = lookup($argus_clients, undef, undef, [])
         $argus_interface = safe_hiera('argus_interface',$facts['interface_default'])
         sunet::nftables::docker_expose { 'allow_https' :
-          allow_clients   => $argus_allow_networks,
-          port            => '443',
-          iif             => $argus_interface,
+          allow_clients => $argus_allow_networks,
+          port          => '443',
+          iif           => $argus_interface,
         }
     } else  {
         warning('No configured Client IPs for argus. Not allowing HTTPS access for anyone.')

--- a/templates/argus/default.conf.erb
+++ b/templates/argus/default.conf.erb
@@ -1,0 +1,26 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+server {
+  listen 443 ssl;
+  http2  on;
+  server_name <%= @url %>;
+
+  ssl_certificate     /etc/letsencrypt/live/<%= @url %>/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/<%= @url %>/privkey.pem;
+
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_pass http://api:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_cache_bypass $http_upgrade;
+  }
+}

--- a/templates/argus/docker-compose.yml.erb
+++ b/templates/argus/docker-compose.yml.erb
@@ -1,0 +1,54 @@
+---
+version: '3.5'
+services:
+  api:
+    image: <%= @docker_image %>:<%= @docker_tag %>
+    expose:
+      - "8000"
+    dns:
+      - 89.32.32.32
+    depends_on:
+      - postgres
+    volumes:
+      - /opt/argus_config/localsettings.py:/opt/venv/lib/python3.13/site-packages/argus/site/settings/localsettings.py
+    environment:
+      - TIME_ZONE=Europe/Oslo
+      - DJANGO_SETTINGS_MODULE=argus.site.settings.localsettings
+      - DATABASE_URL=postgresql://argus:<%= scope.call_function('safe_hiera',['argus_db_password']) %>@postgres/argus
+      - ARGUS_FRONTEND_URL=<%= @url%>
+      - EMAIL_HOST=<%= scope.call_function('safe_hiera',['argus_email_host']) %>
+      - EMAIL_HOST_USER=<%= scope.call_function('safe_hiera',['argus_email_user']) %>
+      - EMAIL_HOST_PASSWORD=<%= scope.call_function('safe_hiera',['argus_email_password']) %>
+      - ARGUS_SEND_NOTIFICATIONS=1
+      - DEFAULT_FROM_EMAIL=<%= scope.call_function('safe_hiera',['argus_email_from']) %>
+      - SMS_GATEWAY_ADDRESS=<%= scope.call_function('safe_hiera',['argus_sms_gateway']) %>
+      - DEFAULT_SMS_MEDIA="argus.notificationprofile.media.sms_as_email.SMSNotification"
+      - EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend"´
+      - SECRET_KEY=<%= scope.call_function('safe_hiera',['django_secret_key']) %>
+    restart: always
+
+  postgres:
+    image: "postgres:18.1"
+    volumes:
+      - postgres:/var/lib/postgresql:Z
+    restart: always
+    environment:
+      - POSTGRES_USER=argus
+      - POSTGRES_PASSWORD=<%= scope.call_function('safe_hiera',['argus_db_password']) %>
+      - POSTGRES_DB=argus
+
+  nginx_argus:
+    container_name: nginx_argus
+    image: "nginx:1.29"
+    depends_on:
+      - postgres
+      - api
+    volumes:
+      - /opt/nginx_etc/conf.d:/etc/nginx/conf.d
+      - /etc/letsencrypt:/etc/letsencrypt
+    ports:
+      - "443:443"
+
+volumes:
+  postgres:
+    driver: local

--- a/templates/argus/docker-compose.yml.erb
+++ b/templates/argus/docker-compose.yml.erb
@@ -15,7 +15,7 @@ services:
       - TIME_ZONE=Europe/Oslo
       - DJANGO_SETTINGS_MODULE=argus.site.settings.localsettings
       - DATABASE_URL=postgresql://argus:<%= scope.call_function('safe_hiera',['argus_db_password']) %>@postgres/argus
-      - ARGUS_FRONTEND_URL=<%= @url%>
+      - ARGUS_FRONTEND_URL=https://<%= @url%>
       - EMAIL_HOST=<%= scope.call_function('safe_hiera',['argus_email_host']) %>
       - EMAIL_HOST_USER=<%= scope.call_function('safe_hiera',['argus_email_user']) %>
       - EMAIL_HOST_PASSWORD=<%= scope.call_function('safe_hiera',['argus_email_password']) %>

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -1,0 +1,38 @@
+from django.core.exceptions import ImproperlyConfigured
+
+from argus.htmx.settings import *
+
+if not FRONTEND_URL:
+    raise ImproperlyConfigured('"FRONTEND_URL" has not been set in production!')
+
+# You must set this: ip-addresses, hostnames and domain names allowed
+# ALLOWED_HOSTS = [
+#     "127.0.0.1",
+#     "localhost",
+# ]
+
+ALLOWED_HOSTS = ["*"]
+
+SECRET_KEY = get_str_env("SECRET_KEY", required=True)
+STATIC_ROOT = get_str_env("STATIC_ROOT", required=True)
+STORAGES["staticfiles"]["BACKEND"] = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = get_str_env("EMAIL_HOST", required=True)
+DEFAULT_FROM_EMAIL = get_str_env("DEFAULT_FROM_EMAIL", required=True)
+
+SEND_NOTIFICATIONS = get_bool_env("ARGUS_SEND_NOTIFICATIONS", default=True)
+
+# Paths to plugins
+MEDIA_PLUGINS = [
+    "argus.notificationprofile.media.email.EmailNotification",
+    "argus.notificationprofile.media.sms_as_email.SMSNotification",
+]
+
+DEFAULT_SMS_MEDIA="argus.notificationprofile.media.sms_as_email.SMSNotification"
+SMS_GATEWAY_ADDRESS=get_str_env("SMS_GATEWAY_ADDRESS", required=False)
+
+# Beware: setting this to something else in production has security implications
+INTERNAL_IPS = []  # Don't alter me, please
+EMAIL_PORT = get_int_env("EMAIL_PORT", 587)
+EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=True)

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -47,9 +47,8 @@ EMAIL_PORT = get_int_env("EMAIL_PORT", 587)
 EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=True)
 
 
-<% if @argus_sso -%>
-    <% case @argus_sso_type
-        when "keycloak" -%>
+<% case @argus_auth_type
+    when "keycloak" -%>
 
 AUTHENTICATION_BACKENDS = [
     "social_core.backends.keycloak.KeycloakOAuth2",
@@ -76,9 +75,13 @@ SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = \
 SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = \
   '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>/protocol/openid-connect/token'
 SOCIAL_AUTH_KEYCLOAK_AUTH_EXTRA_ARGUMENTS = {'kc_idp_hint': '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.kc_idp_hint"]) %>'}
-    <% else -%>
 
-    <% end -%>
+<% when "local" -%>
+
+
+<% when "satosa-oidc" -%>
+
+
 <% end -%>
 
 <% if @argus_debug  -%>

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -56,9 +56,13 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
+
+SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY = \
+  '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_public_key"]) %>'
+
 SOCIAL_AUTH_KEYCLOAK_KEY = '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_key"]) %>'
 SOCIAL_AUTH_KEYCLOAK_SECRET = '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_secret"]) %>'
-#SOCIAL_AUTH_KEYCLOAK_BASE_URL= '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>'
+SOCIAL_AUTH_KEYCLOAK_BASE_URL= '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>'
 
 # Remote authentication support
 REMOTE_AUTH_ENABLED = True

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -36,3 +36,33 @@ SMS_GATEWAY_ADDRESS=get_str_env("SMS_GATEWAY_ADDRESS", required=False)
 INTERNAL_IPS = []  # Don't alter me, please
 EMAIL_PORT = get_int_env("EMAIL_PORT", 587)
 EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=True)
+
+
+<% if @argus_sso -%>
+    <% case @argus_sso_type
+        when "keycloak" -%>
+AUTHENTICATION_BACKENDS = [
+    "social_core.backends.keycloak.KeycloakOAuth2",
+    "django.contrib.auth.backends.ModelBackend",
+]
+
+SOCIAL_AUTH_KEYCLOAK_KEY = <%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_key"]) %>
+SOCIAL_AUTH_KEYCLOAK_SECRET = <%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_secret"]) %>
+#SOCIAL_AUTH_KEYCLOAK_BASE_URL= <%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>
+
+# Remote authentication support
+REMOTE_AUTH_ENABLED = True
+REMOTE_AUTH_BACKEND = 'social_core.backends.keycloak.KeycloakOAuth2'
+
+REMOTE_AUTH_HEADER = get_str_env('REMOTE_AUTH_HEADER', 'HTTP_REMOTE_USER')
+REMOTE_AUTH_AUTO_CREATE_USER = get_bool_env('REMOTE_AUTH_AUTO_CREATE_USER', default=False)
+
+SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = \
+  '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>/protocol/openid-connect/auth'
+SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = \
+  '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>/protocol/openid-connect/token'
+SOCIAL_AUTH_KEYCLOAK_AUTH_EXTRA_ARGUMENTS = {'kc_idp_hint': ''<%= scope.call_function('safe_hiera',["argus_sso_keycloak.kc_idp_hint"]) %>'}
+    <% else -%>
+
+    <% end -%>
+<% end -%>

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -47,9 +47,9 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
-SOCIAL_AUTH_KEYCLOAK_KEY = <%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_key"]) %>
-SOCIAL_AUTH_KEYCLOAK_SECRET = <%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_secret"]) %>
-#SOCIAL_AUTH_KEYCLOAK_BASE_URL= <%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>
+SOCIAL_AUTH_KEYCLOAK_KEY = '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_key"]) %>'
+SOCIAL_AUTH_KEYCLOAK_SECRET = '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_secret"]) %>'
+#SOCIAL_AUTH_KEYCLOAK_BASE_URL= '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>'
 
 # Remote authentication support
 REMOTE_AUTH_ENABLED = True

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -2,6 +2,15 @@ from django.core.exceptions import ImproperlyConfigured
 
 from argus.htmx.settings import *
 
+<% if @argus_debug  -%>
+
+from . import get_bool_env, get_str_env  # noqa: E402
+
+DEBUG = get_bool_env("DEBUG", True)
+TEMPLATES[0]["OPTIONS"]["debug"] = get_bool_env("TEMPLATE_DEBUG", True)  # noqa: F405
+
+<% end -%>
+
 if not FRONTEND_URL:
     raise ImproperlyConfigured('"FRONTEND_URL" has not been set in production!')
 
@@ -67,3 +76,32 @@ SOCIAL_AUTH_KEYCLOAK_AUTH_EXTRA_ARGUMENTS = {'kc_idp_hint': '<%= scope.call_func
 
     <% end -%>
 <% end -%>
+
+<% if @argus_debug  -%>
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'social': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    },
+}
+
+
+LOGGING_CONFIG = None
+if not LOGGING_MODULE:  # noqa: F405
+    LOGGING_MODULE = "argus.site.logging.DEV"
+    DEV_LOGGING = setup_logging(LOGGING_MODULE)  # noqa: F405
+
+DEBUG=True
+
+<% end -%>
+

--- a/templates/argus/localsettings.py.erb
+++ b/templates/argus/localsettings.py.erb
@@ -41,6 +41,7 @@ EMAIL_USE_TLS = get_bool_env("EMAIL_USE_TLS", default=True)
 <% if @argus_sso -%>
     <% case @argus_sso_type
         when "keycloak" -%>
+
 AUTHENTICATION_BACKENDS = [
     "social_core.backends.keycloak.KeycloakOAuth2",
     "django.contrib.auth.backends.ModelBackend",
@@ -61,7 +62,7 @@ SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = \
   '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>/protocol/openid-connect/auth'
 SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = \
   '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.auth_keycloak_base_url"]) %>/protocol/openid-connect/token'
-SOCIAL_AUTH_KEYCLOAK_AUTH_EXTRA_ARGUMENTS = {'kc_idp_hint': ''<%= scope.call_function('safe_hiera',["argus_sso_keycloak.kc_idp_hint"]) %>'}
+SOCIAL_AUTH_KEYCLOAK_AUTH_EXTRA_ARGUMENTS = {'kc_idp_hint': '<%= scope.call_function('safe_hiera',["argus_sso_keycloak.kc_idp_hint"]) %>'}
     <% else -%>
 
     <% end -%>


### PR DESCRIPTION
Argus (https://github.com/Uninett/Argus) is an alarm aggregator and notification tool that is been implemented mostly for CNaaS. 
There is an interest that other projects can make use of this to aggregate different nagios/naemon instances from other separate ops repos. 
This is the first draft for being able to create and provision argus using sunet::argus::server: .

