### PR TITLE
Risk for lost logs

### DIFF
--- a/manifests/dockerhost2.pp
+++ b/manifests/dockerhost2.pp
@@ -119,16 +119,8 @@ class sunet::dockerhost2(
   }
 
   file {
-    '/etc/logrotate.d':
-      ensure => 'directory',
-      mode   => '0755',
-      ;
     '/etc/logrotate.d/docker-containers':
-      ensure  => file,
-      path    => '/etc/logrotate.d/docker-containers',
-      mode    => '0644',
-      content => template('sunet/dockerhost/logrotate_docker-containers.erb'),
-      ;
+      ensure  => absent,
     }
 
     file { '/usr/local/bin/docker-upgrade':

--- a/manifests/dockerhost2.pp
+++ b/manifests/dockerhost2.pp
@@ -120,7 +120,7 @@ class sunet::dockerhost2(
 
   file {
     '/etc/logrotate.d/docker-containers':
-      ensure  => absent,
+      ensure => absent,
     }
 
     file { '/usr/local/bin/docker-upgrade':


### PR DESCRIPTION
It's not recommended to logrotate the docker logs if the json-file driver is in use (which we enforce in daemon.json). The driver will handle the rotation and the extra rotation by logrotate might cause lost logs (from `docker logs`, the logs in syslog are still safe).