### PR TITLE
wget metatadata timeout and retires

### DIFF
--- a/manifests/metadata.pp
+++ b/manifests/metadata.pp
@@ -15,7 +15,7 @@ define sunet::metadata($url=undef,
   $safe_name = regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G')
   $fetch = "fetch_${safe_name}"
   sunet::scriptherder::cronjob { $fetch:
-    cmd           => "sh -c '/usr/bin/wget --no-check-certificate -q ${url} -N -O ${local}.tmp && chmod 0644 ${local}.tmp && ${verify} && mv ${local}.tmp ${local}'",
+    cmd           => "sh -c '/usr/bin/wget --timeout=60 --tries=1 --no-check-certificate -q ${url} -N -O ${local}.tmp && chmod 0644 ${local}.tmp && ${verify} && mv ${local}.tmp ${local}'",
     user          => 'root',
     minute        => '*/5',
     ok_criteria   => ['exit_status=0', 'max_age=25h'],


### PR DESCRIPTION
Lowering default wget timeout and retries in order to avoid OOM on drive IDP servers when retrieving metadata.