### PR TITLE
Fix acme-d certs for alloy

### DIFF
--- a/templates/naemon_monitor/docker-compose.yml.erb
+++ b/templates/naemon_monitor/docker-compose.yml.erb
@@ -161,5 +161,6 @@ services:
 <% end -%>
 <% if @acme_protocol == 'acme-d' -%>
       - "/etc/letsencrypt/live/<%= @domain %>:/etc/dehydrated:ro"
+      - "/etc/letsencrypt/archive/<%= @domain %>/:/archive/<%= @domain %>:ro"
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This needs to be done since the files in the 'live' directory is symlinks to the 'archive' directory. Else the alloy container will not have access to the letsencrypt certs.