### PR TITLE
Workaround since bad cert in classpath

### DIFF
--- a/manifests/bankidp.pp
+++ b/manifests/bankidp.pp
@@ -21,6 +21,7 @@ class sunet::bankidp(
   String $service_path = '/bankid/idp',
   String $spring_config_import = '/config/bankidp.yml',
   String $tz = 'Europe/Stockholm',
+  String $server_root_certificate_path = 'classpath:bankid-trust-prod.crt',
 ) {
 
   $apps = $facts['bankid_cluster_info']['apps']

--- a/templates/bankidp/bankidp.yml.erb
+++ b/templates/bankidp/bankidp.yml.erb
@@ -54,7 +54,7 @@ bankid:
       - http://id.elegnamnden.se/ec/1.0/loa3-pnr
 
 <% if @prod == true %>
-  server-root-certificate: classpath:bankid-trust-prod.crt
+  server-root-certificate: <%= @server_root_certificate_path %>
   service-url: https://appapi2.bankid.com/rp/v6.0
 <% else %>
   server-root-certificate: classpath:bankid-trust-test.crt


### PR DESCRIPTION
Caused by: java.io.IOException: Invalid PEM format:  No EOL char found in footer:  0 x0a

The problem was not the footer but the header