### PR TITLE
Use the moderna docker installation method for ubuntu26+

### DIFF
--- a/manifests/dockerhost2.pp
+++ b/manifests/dockerhost2.pp
@@ -63,7 +63,10 @@ class sunet::dockerhost2(
   $lc_distro = downcase($distro)
   $release = $facts['os']['distro']['release']['major']
 
-  if $distro == 'Ubuntu' or ($distro == 'Debian' and versioncmp($release, '12') <= 0) {
+  if (
+    ($distro == 'Ubuntu' and versioncmp($release, '26') <= 0) or
+    ($distro == 'Debian' and versioncmp($release, '12') <= 0)
+  ) {
     # Add the dockerproject repository, then force an apt-get update before
     # trying to install the package. See https://tickets.puppetlabs.com/browse/MODULES-2190.
     #


### PR DESCRIPTION
We got errors like this:

`Err:5 https://download.docker.com/linux/ubuntu resolute InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8
Warning: OpenPGP signature verification failed: https://download.docker.com/linux/ubuntu resolute InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8
Error: The repository 'https://download.docker.com/linux/ubuntu resolute InRelease' is not signed.
Notice: Updating from such a repository can't be done securely, and is therefore disabled by default.`

This was already fixed for debian, so this PR fixes it for ubuntu26+ as well.