### PR TITLE
Raise the warning age to work with cron interval.

### DIFF
--- a/manifests/metadata/mdq_publisher.pp
+++ b/manifests/metadata/mdq_publisher.pp
@@ -58,7 +58,7 @@ class sunet::metadata::mdq_publisher(
   } -> sunet::nagios::nrpe_check_fileage {
     'metadata_aggregate':
       filename     => '/var/www/html/entities/index.html', # yes this is correct
-      warning_age  => '600',
+      warning_age  => '3600',
       critical_age => '86400'
   }
   ensure_resource('file', '/usr/bin/check-metadata.sh', {


### PR DESCRIPTION
The cronjob runs every 15 minutes so 600 seconds is to low and will result in flapping alarms.