### PR TITLE
Fix issue running ubuntu26 on an ubuntu24 KVM.

### DIFF
--- a/templates/kvm/mk_cloud_image.erb
+++ b/templates/kvm/mk_cloud_image.erb
@@ -34,8 +34,15 @@ if ! echo "${install_options}" | grep -q -- '--osinfo'; then
 		version=$(echo "${image_file}" | cut -d - -f2)
         os_info="${os_info_base} ${dist}${version}"
     else
-        # Assuming Ubuntu at this point since their images doesn't include dist name.
-        os_info="${os_info_base} ubuntu${dist}"
+        osinfo_value="ubuntu${dist}"
+        # virt-install will throw an error if the os is not in the list: "ERROR    Unknown OS name..."
+        # so instead of erroring out we set it to ubuntu-lts-latest which is always in the list
+        # (and probably the issue when running a more modern VM-OS than the KVM-OS)
+        if virt-install --osinfo list 2>/dev/null | grep -qw "${osinfo_value}"; then
+            os_info="${os_info_base}${osinfo_value}"
+        else
+            os_info="${os_info_base}ubuntu-lts-latest"
+        fi
     fi
 fi
 


### PR DESCRIPTION
`ubuntu26.04` or `ubunturesolute` was not in the `virt-install --osinfo list` on a ubuntu24 KVM server. 
This resulted in the following error:
`"ERROR    Unknown OS name 'ubunturesolute'. See --osinfo list for valid values."`

Fixing this by setting a fallback value of `ubuntu-lts-latest` which is always in the list. It's possible that there will be an update later to this list in libvirt that will contain ubuntu26.04 (and then it should not enter the fall-back any more).