### PR TITLE
valkey-fixes

### DIFF
--- a/files/valkey/certbot-renewal-hook
+++ b/files/valkey/certbot-renewal-hook
@@ -1,17 +1,55 @@
-#!/bin/sh -eu
-# vim: ai ts=4 sts=4 et sw=4
+#!/bin/sh
+set -euo pipefail
 
-if ! [ -d '/opt/valkey/cert' ]; then
-    mkdir -p /opt/valkey/cert
+# === Configuration ===
+CERT_DIR="/opt/valkey/cert"
+CERT_DST="${CERT_DIR}/cert.pem"
+KEY_DST="${CERT_DIR}/privkey.pem"
+
+# Valkey runtime UID/GID (inside container)
+VALKEY_UID=999
+VALKEY_GID=999
+
+VALKEY_CLI="valkey-connect"
+
+# === Sanity checks ===
+if [ -z "${RENEWED_LINEAGE:-}" ]; then
+    echo "ERROR: RENEWED_LINEAGE not set (not running from certbot?)" >&2
+    exit 1
 fi
 
-install -m 644 ${RENEWED_LINEAGE}/cert.pem \
-    /opt/valkey/cert/cert.pem
-# group 101 is freerad inside the container
-install -m 640 -g 1000 \
-    ${RENEWED_LINEAGE}/privkey.pem \
-    /opt/valkey/cert/privkey.pem
+if ! command -v "${VALKEY_CLI}" >/dev/null 2>&1; then
+    echo "ERROR: ${VALKEY_CLI} not found" >&2
+    exit 1
+fi
 
-# Touch the cert config to allow for the certificate to be re-read.
-valkey-connect --custom-command "CONFIG SET tls-cert-file /cert/cert.pem"
-valkey-connect --custom-command "CONFIG SET tls-key-file /cert/privkey.pem"
+# === Ensure directory exists ===
+install -d -m 755 "${CERT_DIR}"
+
+# === Install public certificate ===
+install -m 0644 \
+    "${RENEWED_LINEAGE}/cert.pem" \
+    "${CERT_DST}"
+
+# === Install private key securely ===
+install -m 0600 \
+    "${RENEWED_LINEAGE}/privkey.pem" \
+    "${KEY_DST}"
+
+# === Fix ownership explicitly (numeric UID/GID) ===
+chown "${VALKEY_UID}:${VALKEY_GID}" "${KEY_DST}"
+
+# === Defensive stat check (host-safe) ===
+KEY_UID="$(stat -c %u "${KEY_DST}")"
+KEY_MODE="$(stat -c %a "${KEY_DST}")"
+
+if [ "${KEY_UID}" -ne "${VALKEY_UID}" ] || [ "${KEY_MODE}" -ne 600 ]; then
+    echo "ERROR: Incorrect ownership or permissions on ${KEY_DST}" >&2
+    exit 1
+fi
+
+# === Reload TLS material in Valkey ===
+"${VALKEY_CLI}" --custom-command "CONFIG SET tls-cert-file /cert/cert.pem"
+"${VALKEY_CLI}" --custom-command "CONFIG SET tls-key-file /cert/privkey.pem"
+
+echo "Valkey TLS certificates successfully updated"

--- a/manifests/valkey/node.pp
+++ b/manifests/valkey/node.pp
@@ -36,8 +36,13 @@ class sunet::valkey::node(
   $valkey_password = safe_hiera('valkey_password')
 
   # valkey-tools is not available on older OS'es, but redis-tools is compatible with valkey
-  if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '26.04') > 0)
-    or ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '13') > 0) {
+  if (
+    ($facts['os']['name'] == 'Ubuntu' and
+    versioncmp($facts['os']['release']['full'], '26.04') >= 0)
+    or
+    ($facts['os']['name'] == 'Debian' and
+    versioncmp($facts['os']['release']['major'], '13') >= 0)
+  ){
     include sunet::packages::valkey_tools
     $cli_client = 'valkey-cli'
   }

--- a/templates/valkey/bootstrap-valkey.sh.erb
+++ b/templates/valkey/bootstrap-valkey.sh.erb
@@ -12,4 +12,4 @@ for host in <%= @cluster_nodes.join(' ') %>; do
   done
 done
 
-redis-cli --no-auth-warning -a <%= @valkey_password %> --cluster create ${hosts} --cluster-replicas <%= @numnodes - 1 %> --tls --cert /opt/valkey/cert/cert.pem --key /opt/valkey/cert/privkey.pem --cacert <%= @ca_cert_path %>
+<%= @cli_client %> --no-auth-warning -a <%= @valkey_password %> --cluster create ${hosts} --cluster-replicas <%= @numnodes - 1 %> --tls --cert /opt/valkey/cert/cert.pem --key /opt/valkey/cert/privkey.pem --cacert <%= @ca_cert_path %>


### PR DESCRIPTION
- Fix broken OS logic in if-statement
- Fix bootstrap script so it uses the installed CLI tool
- refactor the certbot renewal hook so it works with the fact that the valkey server process inside the container runs with user `valkey` with id `999`. Without this the key file was not readable for the valkey process.
https://github.com/valkey-io/valkey-container/blob/19d0cbdd77fee11a548b74f85697e5973d4ef850/9.0/alpine/Dockerfile#L83-L85
`/data # cat /proc/$(pidof valkey-server)/status | grep Ui
Uid:	999	999	999	999`