### PR TITLE
Add the IPv6 prefix for eduID dev/staging

### DIFF
--- a/lib/puppet/functions/sunet_prefixes.rb
+++ b/lib/puppet/functions/sunet_prefixes.rb
@@ -81,6 +81,7 @@ Puppet::Functions.create_function(:sunet_prefixes) do
       { "net": "2001:6b0:5a:4020::/64", "family": "ip6", "comment": "sunet.se-public (STO1)", "resource_type": "safespring", "tags": ["knubbis", "infraca", "acmec"] },
       { "net": "2001:6b0:8::/48",       "family": "ip6", "comment": "SUNET HOSTING", "resource_type": "SUNET", "tags": ["knubbis", "infraca", "acmec"] },
       { "net": "2001:6b0:40::/48",      "family": "ip6", "comment": "Safespring STO3", "resource_type": "safespring", "tags": ["knubbis", "infraca", "acmec"] },
+      { "net": "2001:6b0:54:c3::/64",   "family": "ip6", "comment": "eduID Dev", "resource_type": "SUNET", "tags": ["knubbis", "infraca", "acmec"] },
       { "net": "2001:6b0:63::/48",      "family": "ip6", "comment": "eduID TUG", "resource_type": "SUNET", "tags": ["knubbis", "infraca", "acmec"] },
       { "net": "2001:6b0:64::/48",      "family": "ip6", "comment": "eduID STHB", "resource_type": "SUNET", "tags": ["knubbis", "infraca", "acmec"] },
       { "net": "2001:6b0:6e::/48",      "family": "ip6", "comment": "Safespring STO4", "resource_type": "safespring", "tags": ["knubbis", "infraca", "acmec"] },


### PR DESCRIPTION
- The IPv6 network for eduID dev/staging is needed for access to the new infra CA