### PR TITLE
disable_resolved_stub: reload systemd-resolved when stub config changes

### DIFF
--- a/manifests/disable_resolved_stub.pp
+++ b/manifests/disable_resolved_stub.pp
@@ -45,10 +45,10 @@ class sunet::disable_resolved_stub(
 
   exec { 'resolved_stub_enable':
     refreshonly => true,
-    command     => 'ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf',
+    command     => 'ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf && systemctl reload-or-restart systemd-resolved',
   }
   exec { 'resolved_stub_disable':
     refreshonly => true,
-    command     => 'ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf',
+    command     => 'ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf && systemctl reload-or-restart systemd-resolved',
   }
 }


### PR DESCRIPTION
Changing the `/etc/resolv.conf` symlink alone does not cause
systemd-resolved to re-read its configuration. Add
`systemctl reload-or-restart systemd-resolved` to both exec
commands so the stub enable/disable actually takes effect.