### PR TITLE
Mikand acmec changes

### DIFF
--- a/files/dehydrated/check_acmec-allowed-prefixes.py
+++ b/files/dehydrated/check_acmec-allowed-prefixes.py
@@ -57,8 +57,6 @@ def remove_unused_checks(all_domains):
         if fname not in all_domains and fname not in exclusions:
             print(f"Removing {filepath}")
             os.remove(filepath)
-        else:
-            pass
 
 def resolve_host(hostname):
     ips = set()

--- a/files/dehydrated/check_acmec-allowed-prefixes.py
+++ b/files/dehydrated/check_acmec-allowed-prefixes.py
@@ -3,12 +3,14 @@ import yaml
 import sys
 import socket
 import re
+import os
 import json
 from ipaddress import ip_network, ip_address
 import argparse
 
 def parse_acmec_non_clients(yaml_path):
     result = []
+    all_domains = []
 
     with open(yaml_path, "r") as f:
         data = yaml.safe_load(f)
@@ -24,7 +26,8 @@ def parse_acmec_non_clients(yaml_path):
         if not isinstance(item, dict):
             continue
 
-        for _, props in item.items():
+        for domain, props in item.items():
+            all_domains.append(domain)
             if not isinstance(props, dict):
                 continue
 
@@ -37,7 +40,25 @@ def parse_acmec_non_clients(yaml_path):
                 result.extend(names)
 
     # normalize + dedupe
-    return list(dict.fromkeys(h.strip().lower() for h in result if h and h.strip()))
+    return list(dict.fromkeys(h.strip().lower() for h in result if h and h.strip())), list(dict.fromkeys(h.strip().lower() for h in all_domains if h and h.strip()))
+
+def remove_unused_checks(all_domains):
+    exclusions = ["gather_inventory", "dehydrated", "update_and_upgrade", "cleanup", "check_infra_cert", "cosmos"]
+
+    files = os.listdir("/etc/scriptherder/check/")
+
+    for f in files:
+        if not f.endswith(".ini"):
+            continue
+        
+        fname = f[:-4].replace("dehydrated_", "")
+        filepath = f"/etc/scriptherder/check/{f}"
+        
+        if fname not in all_domains and fname not in exclusions:
+            print(f"Removing {filepath}")
+            os.remove(filepath)
+        else:
+            pass
 
 def resolve_host(hostname):
     ips = set()
@@ -131,13 +152,18 @@ if __name__ == "__main__":
 
     prefixes = load_prefixes("/etc/puppet/cosmos-modules/sunet/lib/puppet/functions/sunet_prefixes.rb")
 
-    acmec_clients = parse_acmec_non_clients("/etc/hiera/data/local.yaml")
+    acmec_non_clients, all_acmec_domains = parse_acmec_non_clients("/etc/hiera/data/local.yaml")
+    remove_unused_checks(all_acmec_domains)
 
-    all_hosts = list(dict.fromkeys(acmec_clients))
+    all_hosts = list(dict.fromkeys(acmec_non_clients))
 
     results = check_hostnames(prefixes, all_hosts, required_tag)
 
     not_resolvable, missing_sunet_prefix, missing_acmec_tag = results
+
+    if not_resolvable and missing_sunet_prefix and missing_acmec_tag:
+        print('OK')
+        sys.exit(0)
     
     print("\n\nNot resolvable:")
     if not not_resolvable:

--- a/files/dehydrated/check_acmec_allowed_prefixes.py
+++ b/files/dehydrated/check_acmec_allowed_prefixes.py
@@ -3,14 +3,12 @@ import yaml
 import sys
 import socket
 import re
-import os
 import json
 from ipaddress import ip_network, ip_address
 import argparse
 
 def parse_acmec_non_clients(yaml_path):
     result = []
-    all_domains = []
 
     with open(yaml_path, "r") as f:
         data = yaml.safe_load(f)
@@ -26,8 +24,7 @@ def parse_acmec_non_clients(yaml_path):
         if not isinstance(item, dict):
             continue
 
-        for domain, props in item.items():
-            all_domains.append(domain)
+        for _, props in item.items():
             if not isinstance(props, dict):
                 continue
 
@@ -40,23 +37,7 @@ def parse_acmec_non_clients(yaml_path):
                 result.extend(names)
 
     # normalize + dedupe
-    return list(dict.fromkeys(h.strip().lower() for h in result if h and h.strip())), list(dict.fromkeys(h.strip().lower() for h in all_domains if h and h.strip()))
-
-def remove_unused_checks(all_domains):
-    exclusions = ["gather_inventory", "dehydrated", "update_and_upgrade", "cleanup", "check_infra_cert", "cosmos"]
-
-    files = os.listdir("/etc/scriptherder/check/")
-
-    for f in files:
-        if not f.endswith(".ini"):
-            continue
-        
-        fname = f[:-4].replace("dehydrated_", "")
-        filepath = f"/etc/scriptherder/check/{f}"
-        
-        if fname not in all_domains and fname not in exclusions:
-            print(f"Removing {filepath}")
-            os.remove(filepath)
+    return list(dict.fromkeys(h.strip().lower() for h in result if h and h.strip()))
 
 def resolve_host(hostname):
     ips = set()
@@ -150,10 +131,9 @@ if __name__ == "__main__":
 
     prefixes = load_prefixes("/etc/puppet/cosmos-modules/sunet/lib/puppet/functions/sunet_prefixes.rb")
 
-    acmec_non_clients, all_acmec_domains = parse_acmec_non_clients("/etc/hiera/data/local.yaml")
-    remove_unused_checks(all_acmec_domains)
+    acmec_clients = parse_acmec_non_clients("/etc/hiera/data/local.yaml")
 
-    all_hosts = list(dict.fromkeys(acmec_non_clients))
+    all_hosts = list(dict.fromkeys(acmec_clients))
 
     results = check_hostnames(prefixes, all_hosts, required_tag)
 

--- a/files/dehydrated/remove_unused_checks.py
+++ b/files/dehydrated/remove_unused_checks.py
@@ -1,11 +1,18 @@
 import yaml
 import os
+import sys
 
 # Remove acmec checks and cached check data for domains not existing in local.yaml
 def remove_unused_checks(all_acmec_domains):
+    has_errors = False
     exclusions = ["gather_inventory", "dehydrated", "update_and_upgrade", "cleanup", "check_infra_cert", "cosmos"]
-    files = os.listdir("/etc/scriptherder/check/")
-    cfiles = os.listdir("/var/cache/scriptherder")
+    
+    try:
+        files = os.listdir("/etc/scriptherder/check/")
+        cfiles = os.listdir("/var/cache/scriptherder")
+    except OSError as e:
+        print(f"Failed to list directories: {e}")
+        return True
 
     for f in files:
         if not f.endswith(".ini"):
@@ -15,8 +22,14 @@ def remove_unused_checks(all_acmec_domains):
         filepath = f"/etc/scriptherder/check/{f}"
         
         if fname not in all_acmec_domains and fname not in exclusions:
-            os.remove(filepath)
-
+            # Try to remove the .ini file
+            try:
+                os.remove(filepath)
+                print(f"Removed unused check: {filepath}")
+            except OSError as e:
+                print(f"Failed to remove {filepath}: {e}")
+                has_errors = True
+            
             # Build the cache prefix from the .ini filename
             cfname = f[:-4].replace(".", "_")
             
@@ -24,7 +37,15 @@ def remove_unused_checks(all_acmec_domains):
             for cfile in cfiles:
                 if cfile.startswith(cfname + "__"):
                     cfilepath = f"/var/cache/scriptherder/{cfile}"
-                    os.remove(cfilepath)
+                    try:
+                        os.remove(cfilepath)
+                        print(f"Removed unused check caches: {cfilepath}")
+                    except OSError as e:
+                        print(f"Failed to remove {cfilepath}: {e}")
+                        has_errors = True
+
+    return has_errors
+
 
 def parse_acmec_domains(yaml_path):
     all_domains = []
@@ -45,5 +66,9 @@ def parse_acmec_domains(yaml_path):
     return list(dict.fromkeys(h.strip().lower() for h in all_domains if h and h.strip()))
 
 if __name__ == "__main__":
- all_acmec_domains = parse_acmec_domains("/etc/hiera/data/local.yaml")
- remove_unused_checks(all_acmec_domains)
+    all_acmec_domains = parse_acmec_domains("/etc/hiera/data/local.yaml")
+    
+    if remove_unused_checks(all_acmec_domains):
+        sys.exit(2)
+    else:
+        sys.exit(0)

--- a/files/dehydrated/remove_unused_checks.py
+++ b/files/dehydrated/remove_unused_checks.py
@@ -1,0 +1,50 @@
+import yaml
+import os
+
+# Remove acmec checks and cached check data for domains not existing in local.yaml
+def remove_unused_checks(all_acmec_domains):
+    exclusions = ["gather_inventory", "dehydrated", "update_and_upgrade", "cleanup", "check_infra_cert", "cosmos"]
+    files = os.listdir("/etc/scriptherder/check/")
+    cfiles = os.listdir("/var/cache/scriptherder")
+
+    for f in files:
+        if not f.endswith(".ini"):
+            continue
+        
+        fname = f[:-4].replace("dehydrated_", "").strip().lower()
+        filepath = f"/etc/scriptherder/check/{f}"
+        
+        if fname not in all_acmec_domains and fname not in exclusions:
+            print(f"Removing {filepath}")
+            os.remove(filepath)
+
+            # Build the cache prefix from the .ini filename
+            cfname = f[:-4].replace(".", "_")
+            
+            # Find and remove all cache files for this specific check
+            for cfile in cfiles:
+                if cfile.startswith(cfname + "__"):
+                    cfilepath = f"/var/cache/scriptherder/{cfile}"
+                    os.remove(cfilepath)
+
+def parse_acmec_domains(yaml_path):
+    all_domains = []
+
+    with open(yaml_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    dehydrated = data.get("dehydrated", {})
+
+    for item in dehydrated.get("domains", []):
+        if not isinstance(item, dict):
+            continue
+
+        for domain, props in item.items():
+            all_domains.append(domain)
+
+    # Normalize and deduplicate
+    return list(dict.fromkeys(h.strip().lower() for h in all_domains if h and h.strip()))
+
+if __name__ == "__main__":
+ all_acmec_domains = parse_acmec_domains("/etc/hiera/data/local.yaml")
+ remove_unused_checks(all_acmec_domains)

--- a/files/dehydrated/remove_unused_checks.py
+++ b/files/dehydrated/remove_unused_checks.py
@@ -15,7 +15,6 @@ def remove_unused_checks(all_acmec_domains):
         filepath = f"/etc/scriptherder/check/{f}"
         
         if fname not in all_acmec_domains and fname not in exclusions:
-            print(f"Removing {filepath}")
             os.remove(filepath)
 
             # Build the cache prefix from the .ini filename

--- a/files/dehydrated/remove_unused_checks.py
+++ b/files/dehydrated/remove_unused_checks.py
@@ -5,37 +5,36 @@ import sys
 # Remove acmec checks and cached check data for domains not existing in local.yaml
 def remove_unused_checks(all_acmec_domains):
     has_errors = False
-    exclusions = ["gather_inventory", "dehydrated", "update_and_upgrade", "cleanup", "check_infra_cert", "cosmos"]
     
     try:
-        files = os.listdir("/etc/scriptherder/check/")
-        cfiles = os.listdir("/var/cache/scriptherder")
+        checks = os.listdir("/etc/scriptherder/check/")
+        cached_checks = os.listdir("/var/cache/scriptherder")
     except OSError as e:
         print(f"Failed to list directories: {e}")
         return True
 
-    for f in files:
-        if not f.endswith(".ini"):
+    for f in checks:
+        if not f.startswith("dehydrated_") or not f.endswith(".ini"):
             continue
         
-        fname = f[:-4].replace("dehydrated_", "").strip().lower()
-        filepath = f"/etc/scriptherder/check/{f}"
+        fn_check = f[:-4].replace("dehydrated_", "").strip().lower()
+        fp_check = f"/etc/scriptherder/check/{f}"
         
-        if fname not in all_acmec_domains and fname not in exclusions:
+        if fn_check not in all_acmec_domains:
             # Try to remove the .ini file
             try:
-                os.remove(filepath)
-                print(f"Removed unused check: {filepath}")
+                os.remove(fp_check)
+                print(f"Removed unused check: {fp_check}")
             except OSError as e:
-                print(f"Failed to remove {filepath}: {e}")
+                print(f"Failed to remove {fp_check}: {e}")
                 has_errors = True
             
             # Build the cache prefix from the .ini filename
-            cfname = f[:-4].replace(".", "_")
+            fn_cache = f[:-4].replace(".", "_")
             
             # Find and remove all cache files for this specific check
-            for cfile in cfiles:
-                if cfile.startswith(cfname + "__"):
+            for cfile in cached_checks:
+                if cfile.startswith(fn_cache + "__"):
                     cfilepath = f"/var/cache/scriptherder/{cfile}"
                     try:
                         os.remove(cfilepath)

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -97,18 +97,9 @@ class sunet::dehydrated(
   }
 
   if ($cron) {
-    sunet::scriptherder::cronjob { 'dehydrated_cleanup':
-      cmd           => 'python3 /etc/dehydrated/remove_unused_checks.py',
-      hour          => '23',
-      minute        => '0',
-      ok_criteria   => ['exit_status=0','max_age=4d'],
-      warn_criteria => ['exit_status=1','max_age=8d'],
-    }
-
     sunet::scriptherder::cronjob { 'dehydrated':
       cmd           => '/etc/dehydrated/dehydrated_wrapper.sh',
-      hour          => '0',
-      minute        => '0',
+      special       => 'daily',
       ok_criteria   => ['exit_status=0','max_age=4d'],
       warn_criteria => ['exit_status=1','max_age=8d'],
     }

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -97,9 +97,18 @@ class sunet::dehydrated(
   }
 
   if ($cron) {
+    sunet::scriptherder::cronjob { 'dehydrated_cleanup':
+      cmd           => 'python3 /etc/dehydrated/remove_unused_checks.py',
+      hour          => 23,
+      minute        => 0,
+      ok_criteria   => ['exit_status=0','max_age=4d'],
+      warn_criteria => ['exit_status=1','max_age=8d'],
+    }
+
     sunet::scriptherder::cronjob { 'dehydrated':
       cmd           => '/etc/dehydrated/dehydrated_wrapper.sh',
-      special       => 'daily',
+      hour          => 0,
+      minute        => 0,
       ok_criteria   => ['exit_status=0','max_age=4d'],
       warn_criteria => ['exit_status=1','max_age=8d'],
     }

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -65,6 +65,11 @@ class sunet::dehydrated(
       ensure  => 'file',
       content => '# Intentionally left blank for dehydrated',
       ;
+    '/etc/dehydrated/dehydrated_one.sh':
+      ensure  => 'file',
+      content => template('sunet/dehydrated/dehydrated_one.sh.erb'),
+      mode    => '0755',
+      ;
   }
 
   $encoded_url = base64('encode', 'https://acme-v02.api.letsencrypt.org/directory')

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -99,16 +99,16 @@ class sunet::dehydrated(
   if ($cron) {
     sunet::scriptherder::cronjob { 'dehydrated_cleanup':
       cmd           => 'python3 /etc/dehydrated/remove_unused_checks.py',
-      hour          => 23,
-      minute        => 0,
+      hour          => '23',
+      minute        => '0',
       ok_criteria   => ['exit_status=0','max_age=4d'],
       warn_criteria => ['exit_status=1','max_age=8d'],
     }
 
     sunet::scriptherder::cronjob { 'dehydrated':
       cmd           => '/etc/dehydrated/dehydrated_wrapper.sh',
-      hour          => 0,
-      minute        => 0,
+      hour          => '0',
+      minute        => '0',
       ok_criteria   => ['exit_status=0','max_age=4d'],
       warn_criteria => ['exit_status=1','max_age=8d'],
     }

--- a/manifests/dehydrated.pp
+++ b/manifests/dehydrated.pp
@@ -72,6 +72,14 @@ class sunet::dehydrated(
       ;
   }
 
+    file { '/etc/dehydrated/remove_unused_checks.py':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+    content => file('sunet/dehydrated/remove_unused_checks.py'),
+  }
+
   $encoded_url = base64('encode', 'https://acme-v02.api.letsencrypt.org/directory')
   exec { 'dehydrated-registration':
     command => 'dehydrated --register --accept-terms',
@@ -152,22 +160,22 @@ class sunet::dehydrated(
   if $allow_prefixes_by_tag != [] {
     $allow_clients_ssh = sunet_prefixes({tags => $allow_prefixes_by_tag, family=>'ip'}) + sunet_prefixes({tags => $allow_prefixes_by_tag, family=>'ip6'})
 
-    file { '/usr/lib/nagios/plugins/check_acmec-allowed-prefixes':
+    file { '/usr/lib/nagios/plugins/check_acmec_allowed_prefixes':
       ensure  => file,
       owner   => 'root',
       group   => 'root',
       mode    => '0755',
-      content => file('sunet/dehydrated/check_acmec-allowed-prefixes.py'),
+      content => file('sunet/dehydrated/check_acmec_allowed_prefixes.py'),
     }
 
-    sunet::sudoer {'check_acmec-allowed-prefixes':
+    sunet::sudoer {'check_acmec_allowed_prefixes':
         user_name    => 'nagios',
-        collection   => 'check_acmec-allowed-prefixes',
-        command_line => '/usr/lib/nagios/plugins/check_acmec-allowed-prefixes'
+        collection   => 'check_acmec_allowed_prefixes',
+        command_line => '/usr/lib/nagios/plugins/check_acmec_allowed_prefixes'
       }
 
     sunet::nagios::nrpe_command {'check_acmec-allowed-prefixes':
-      command_line => '/usr/lib/nagios/plugins/check_acmec-allowed-prefixes --tag acmec'
+      command_line => '/usr/lib/nagios/plugins/check_acmec_allowed_prefixes --tag acmec'
     }
   } else {
     $allow_clients_ssh = $allow_clients

--- a/manifests/security/cve_mitigator.pp
+++ b/manifests/security/cve_mitigator.pp
@@ -53,4 +53,20 @@ class sunet::security::cve_mitigator (
       refreshonly => true,
     }
   }
+
+  # ssh-keysign-pwn
+  # CVE-2026-46333
+  if !('ssh_keysign_pwn' in $_excluded_cves) {
+    file { '/etc/sysctl.d/99-ssh-keysign-pwn.conf':
+      ensure  => present,
+      content => @("EOF"),
+       kernel.yama.ptrace_scope = 3
+       | EOF
+    }
+    exec { 'ssh_keysign_pwn_sysctl_setting':
+      command     => 'sysctl -w kernel.yama.ptrace_scope=3 2>/dev/null; true',
+      subscribe   => File['/etc/sysctl.d/99-ssh-keysign-pwn.conf'],
+      refreshonly => true,
+    }
+  }
 }

--- a/templates/dehydrated/dehydrated_one.sh.erb
+++ b/templates/dehydrated/dehydrated_one.sh.erb
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <hostname>"
+    exit 1
+fi
+
+HOSTNAME="$1"
+DOMAINFILE="/etc/dehydrated/domains.txt"
+SCRIPTHERDER="/usr/local/bin/scriptherder"
+SCRIPTHERDER_TEMPLATE="/etc/scriptherder/check/dehydrated.ini"
+DEHYDRATED="/usr/sbin/dehydrated"
+HOOKFILE="/etc/dehydrated/hook.sh"
+CONFIGFILE="/etc/dehydrated/config"
+
+# verify domain exists
+if ! grep -qE "^${HOSTNAME}[[:space:]]" "$DOMAINFILE"; then
+    echo "ERROR: ${HOSTNAME} not found in ${DOMAINFILE}"
+    exit 2
+fi
+
+JOBNAME="dehydrated_${HOSTNAME}"
+JOBFILE="/etc/scriptherder/check/${JOBNAME}.ini"
+
+# create scriptherder config if missing
+if [[ ! -f "$JOBFILE" ]]; then
+    cp "$SCRIPTHERDER_TEMPLATE" "$JOBFILE"
+fi
+
+# run dehydrated only for this domain
+"$SCRIPTHERDER" --mode wrap --syslog --name "$JOBNAME" -- "$DEHYDRATED" --cron --domain "$HOSTNAME" --hook "$HOOKFILE" --config "$CONFIGFILE" --force
+
+# update compatibility symlinks etc
+/usr/bin/le-ssl-compat.sh

--- a/templates/dehydrated/dehydrated_wrapper.sh.erb
+++ b/templates/dehydrated/dehydrated_wrapper.sh.erb
@@ -34,7 +34,8 @@ do
       sleep 5
       waited=$((waited + 5))
       if [ "${waited}" -ge 300 ]; then
-          exit 1
+          rm -f "${LOCKFILE}"
+          break
       fi
   done
 

--- a/templates/dehydrated/dehydrated_wrapper.sh.erb
+++ b/templates/dehydrated/dehydrated_wrapper.sh.erb
@@ -17,6 +17,11 @@ SCRIPTHERDER_TEMPLATE="/etc/dehydrated/scriptherder_template.ini"
 DEHYDRATED="/usr/sbin/dehydrated"
 DEHYDRATED_OPTIONS="--no-lock --hook ${HOOKFILE} --config ${CONFIGFILE} "
 DEHYDRATED_VERB="--cron"
+ORDER_TIMEOUT=300
+VALIDATION_TIMEOUT=120
+
+# Remove unused checks before renewal
+python3 /etc/dehydrated/remove_unused_checks.py
 
 DOMAINFILE_TEMP="$(mktemp)" 
 if [[ -n "$1" ]]; then
@@ -44,7 +49,7 @@ do
   CONFIG_SINGLEDOMAIN="/etc/dehydrated/config-singledomain"
   echo "DOMAINS_TXT=\"${SINGLEDOMAIN}\"" > ${CONFIG_SINGLEDOMAIN} 
   JOBNAME="dehydrated_`awk '{ print $1 }' ${SINGLEDOMAIN}`"
-  ${SCRIPTHERDER} ${SCRIPTHERDER_OPTIONS} ${JOBNAME} -- ${DEHYDRATED} ${DEHYDRATED_VERB} --config ${CONFIG_SINGLEDOMAIN} && /usr/bin/le-ssl-compat.sh
+  ${SCRIPTHERDER} ${SCRIPTHERDER_OPTIONS} ${JOBNAME} -- ${DEHYDRATED} ${DEHYDRATED_VERB} --config ${CONFIG_SINGLEDOMAIN} --order-timeout ${ORDER_TIMEOUT} --validation-timeout ${VALIDATION_TIMEOUT}  && /usr/bin/le-ssl-compat.sh
   JOBFILE="/etc/scriptherder/check/${JOBNAME}.ini" 
   if [ ! -f "$JOBFILE" ]; then
     /bin/cp $SCRIPTHERDER_TEMPLATE /etc/scriptherder/check/${JOBNAME}.ini

--- a/templates/dehydrated/dehydrated_wrapper.sh.erb
+++ b/templates/dehydrated/dehydrated_wrapper.sh.erb
@@ -27,6 +27,17 @@ fi
 
 /bin/cat "${DOMAINFILE_TEMP}" | while read line
 do
+  # Wait for lock before each domain
+  LOCKFILE="/etc/dehydrated/lock"
+  waited=0
+  while [ -f "${LOCKFILE}" ]; do
+      sleep 5
+      waited=$((waited + 5))
+      if [ "${waited}" -ge 300 ]; then
+          exit 1
+      fi
+  done
+
   SINGLEDOMAIN=$(mktemp)
   echo $line > ${SINGLEDOMAIN}
   CONFIG_SINGLEDOMAIN="/etc/dehydrated/config-singledomain"

--- a/templates/dehydrated/dehydrated_wrapper.sh.erb
+++ b/templates/dehydrated/dehydrated_wrapper.sh.erb
@@ -60,7 +60,7 @@ done
 rm "${DOMAINFILE_TEMP}"
 
 <% if @cleanup %>
-  JOBNAME="dehydrated_cleanup"
+  JOBNAME="cleanup_dehydrated"
   JOBFILE="/etc/scriptherder/check/${JOBNAME}.ini" 
   if [ ! -f "$JOBFILE" ]; then
     /bin/cp $SCRIPTHERDER_TEMPLATE /etc/scriptherder/check/${JOBNAME}.ini


### PR DESCRIPTION
dehydrated_one
- Removed obsolete code, added error handling and safeguards.
- Force cert renewal for one domain

dehydrated_wrapper
- Added lockfile handling, timeout if process get stuck to allow continued script execution.
- adding timeouts for ORDER_TIMEOUT and VALIDATION_TIMEOUT. As dehydrated doesn't set defaults the process might get stuck.

remove_unused_checks
- Now included in dehydrated_wrapper instead of a separate cronjob
- removes old unused checks/domains not existing in local.yaml, including cached scriptherder information
- removing exclusions array and changing cleanup job name in order to not having to maintain an exclusions list.
