### PR TITLE
docker_expose: allow_local param and unified dnat_dport

### DIFF
--- a/manifests/nftables/docker_expose.pp
+++ b/manifests/nftables/docker_expose.pp
@@ -5,6 +5,7 @@
 # @param dnat_v4_addr   IPv4 address of Docker bridge (the IP address of docker on the to_docker veth pair).
 # @param dnat_v6_addr   IPv6 address to use for DNAT. Docker won't set up DNAT for IPv6, so provide the containers v6 addr here.
 # @param dnat_v6_port   Port to use for v6 DNAT. Docker won't set up DNAT for IPv6, so provide the containers v6 port here.
+# @param allow_local    Allow access from docker containers on this host to the exposed service.
 define sunet::nftables::docker_expose (
   Variant[String, Array[String]] $allow_clients, # Allow traffic 'from' this IP (or list of IP:s).
   Variant[Integer, String] $port,  # Allow traffic to this port
@@ -13,6 +14,7 @@ define sunet::nftables::docker_expose (
   String $dnat_v4_addr = '172.16.0.2',
   String $dnat_v6_addr = 'fd00::2',
   Variant[Integer, String] $dnat_v6_port = $port,
+  Boolean $allow_local = false,
 ) {
   $safe_name = regsubst($title, '[^0-9A-Za-z_]', '_', 'G')
 

--- a/manifests/nftables/docker_expose.pp
+++ b/manifests/nftables/docker_expose.pp
@@ -1,10 +1,11 @@
 # set up DNAT port forwarding of $port to Docker
 # @param allow_clients  Clients to allow traffic from. List of IP addresses or CIDR blocks.
-# @param port           Port to allow traffic to.
+# @param port           Port to allow traffic to (external/host-side port).
 # @param proto          Protocol to allow traffic for.
 # @param dnat_v4_addr   IPv4 address of Docker bridge (the IP address of docker on the to_docker veth pair).
 # @param dnat_v6_addr   IPv6 address to use for DNAT. Docker won't set up DNAT for IPv6, so provide the containers v6 addr here.
-# @param dnat_v6_port   Port to use for v6 DNAT. Docker won't set up DNAT for IPv6, so provide the containers v6 port here.
+# @param dnat_dport     Container-side port to DNAT to (both v4 and v6). Defaults to $port (same inside and outside).
+# @param dnat_v6_port   Deprecated alias for dnat_dport.
 # @param allow_local    Allow access from docker containers on this host to the exposed service.
 define sunet::nftables::docker_expose (
   Variant[String, Array[String]] $allow_clients, # Allow traffic 'from' this IP (or list of IP:s).
@@ -13,9 +14,17 @@ define sunet::nftables::docker_expose (
   String $iif = 'eth0',
   String $dnat_v4_addr = '172.16.0.2',
   String $dnat_v6_addr = 'fd00::2',
-  Variant[Integer, String] $dnat_v6_port = $port,
+  Variant[Integer, String] $dnat_dport = $port,
+  Optional[Variant[Integer, String]] $dnat_v6_port = undef,
   Boolean $allow_local = false,
 ) {
+  if $dnat_v6_port != undef {
+    warning("${module_name}: dnat_v6_port is deprecated, use dnat_dport instead")
+    $_dnat_dport = $dnat_v6_port
+  } else {
+    $_dnat_dport = $dnat_dport
+  }
+
   $safe_name = regsubst($title, '[^0-9A-Za-z_]', '_', 'G')
 
   $docker_class = $::facts['dockerhost2'] ? {
@@ -33,7 +42,7 @@ define sunet::nftables::docker_expose (
     $saddr_v6 = sunet::format_nft_set('ip6 saddr', $allow_clients_v6)
     $daddr_v6 = sunet::format_nft_set('ip6 daddr', [$dnat_v6_addr])
     $dport = sunet::format_nft_set('dport', $port)
-    $v6_dnat_dport = sunet::format_nft_set('dport', $dnat_v6_port)
+    $dnat_dport_set = sunet::format_nft_set('dport', $_dnat_dport)
 
     if ! has_key($::facts['networking']['interfaces'], 'to_docker') {
       notice('No to_docker interface found, not setting up the DNAT rules for Docker (will probably work next time)')

--- a/templates/nftables/600-docker_expose.nft.erb
+++ b/templates/nftables/600-docker_expose.nft.erb
@@ -2,17 +2,17 @@
 # DNAT packets to an exposed service running in a Docker container
 #
 <% if @saddr_v4.is_a? String -%>
-add rule ip nat prerouting iifname <%= @iif %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %>"
+add rule ip nat prerouting iifname <%= @iif %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %>:<%= @_dnat_dport %> comment "docker_expose <%= @name %>"
 <% if @ipaddress_default -%>
-add rule ip nat output oifname lo ip saddr <%= @ipaddress_default -%> ip daddr <%= @ipaddress_default -%> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %> loopback"
-add rule ip nat postrouting oifname <%= @iif %> ip saddr <%= @ipaddress_default -%> ip daddr <%= @dnat_v4_addr %> <%= @proto -%> <%= @dport %> comment "docker_expose <%= @name %> loopback"
+add rule ip nat output oifname lo ip saddr <%= @ipaddress_default -%> ip daddr <%= @ipaddress_default -%> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %>:<%= @_dnat_dport %> comment "docker_expose <%= @name %> loopback"
+add rule ip nat postrouting oifname <%= @iif %> ip saddr <%= @ipaddress_default -%> ip daddr <%= @dnat_v4_addr %> <%= @proto -%> <%= @dnat_dport_set %> comment "docker_expose <%= @name %> loopback"
 <% end -%>
 <% end -%>
 <% if @saddr_v6.is_a? String -%>
-add rule ip6 nat prerouting iifname <%= @iif %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>]:<%= @dnat_v6_port %> comment "docker_expose <%= @name %> (v6 DNAT)"
+add rule ip6 nat prerouting iifname <%= @iif %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>]:<%= @_dnat_dport %> comment "docker_expose <%= @name %> (v6 DNAT)"
 <% if @ipaddress6_default -%>
 add rule ip6 nat output oifname lo ip6 saddr <%= @ipaddress6_default -%> ip6 daddr <%= @ipaddress6_default %> <%= @proto -%> <%= @dport %> dnat to [<%= @dnat_v6_addr %>] comment "docker_expose <%= @name %> (v6 DNAT loopback)"
-add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr <%= @dnat_v6_addr %> <%= @proto -%> <%= @dport %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
+add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_default %> ip6 daddr <%= @dnat_v6_addr %> <%= @proto -%> <%= @dnat_dport_set %> comment "docker_expose <%= @name %> (v6 DNAT loopback)"
 <% end -%>
 <% end -%>
 
@@ -20,16 +20,16 @@ add rule ip6 nat postrouting oifname <%= @iif %> ip6 saddr <%= @ipaddress6_defau
 # Allow forwarding of the packets to the exposed service
 #
 <% if @saddr_v4.is_a? String -%>
-add rule inet filter forward oifname "to_docker" <%= @saddr_v4 %> <%= @proto -%> <%= @dport %> counter accept comment "docker_expose <%= @name %>"
+add rule inet filter forward oifname "to_docker" <%= @saddr_v4 %> <%= @proto -%> <%= @dnat_dport_set %> counter accept comment "docker_expose <%= @name %>"
 <% end -%>
 <% if @saddr_v6.is_a? String -%>
-add rule inet filter forward oifname "to_docker" <%= @saddr_v6 %> <%= @daddr_v6 %> <%= @proto -%> <%= @v6_dnat_dport %> counter accept comment "docker_expose <%= @name %>"
+add rule inet filter forward oifname "to_docker" <%= @saddr_v6 %> <%= @daddr_v6 %> <%= @proto -%> <%= @dnat_dport_set %> counter accept comment "docker_expose <%= @name %>"
 <% end -%>
 
 <% if @allow_local == true %>
 # Allow access from docker containers on this host to the exposed service
 add rule inet filter input iifname "to_docker" <%= @proto -%> <%= @dport %> counter accept comment "docker_expose <%= @name %>"
 <% if @ipaddress_default -%>
-add rule ip nat prerouting iifname "to_docker" ip daddr <%= @ipaddress_default %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %> (docker loopback)"
+add rule ip nat prerouting iifname "to_docker" ip daddr <%= @ipaddress_default %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %>:<%= @_dnat_dport %> comment "docker_expose <%= @name %> (docker loopback)"
 <% end -%>
 <% end -%>

--- a/templates/nftables/600-docker_expose.nft.erb
+++ b/templates/nftables/600-docker_expose.nft.erb
@@ -25,3 +25,11 @@ add rule inet filter forward oifname "to_docker" <%= @saddr_v4 %> <%= @proto -%>
 <% if @saddr_v6.is_a? String -%>
 add rule inet filter forward oifname "to_docker" <%= @saddr_v6 %> <%= @daddr_v6 %> <%= @proto -%> <%= @v6_dnat_dport %> counter accept comment "docker_expose <%= @name %>"
 <% end -%>
+
+<% if @allow_local == true %>
+# Allow access from docker containers on this host to the exposed service
+add rule inet filter input iifname "to_docker" <%= @proto -%> <%= @dport %> counter accept comment "docker_expose <%= @name %>"
+<% if @ipaddress_default -%>
+add rule ip nat prerouting iifname "to_docker" ip daddr <%= @ipaddress_default %> <%= @proto -%> <%= @dport %> dnat to <%= @dnat_v4_addr %> comment "docker_expose <%= @name %> (docker loopback)"
+<% end -%>
+<% end -%>


### PR DESCRIPTION
## Summary

- Add `allow_local` param to permit intra-host Docker container access to the exposed service (adds nftables input + DNAT loopback rules)
- Add `dnat_dport` param that applies to both v4 and v6 DNAT, replacing the v6-only `dnat_v6_port`. The old param is kept as a deprecated alias with a warning.