### PR TITLE
ssh_keyscan: AppArmor local override on Ubuntu 26.04+

### DIFF
--- a/manifests/ssh_keyscan.pp
+++ b/manifests/ssh_keyscan.pp
@@ -19,4 +19,25 @@ class sunet::ssh_keyscan(
     content => "# do not edit by hand - maintained by sunet::ssh_keyscan\n",
     order   => '10',
   }
+
+  # AppArmor profile on Ubuntu 26.04+ restricts ssh-keyscan to network only.
+  # Add local override to permit reading the hosts file.
+  if $facts['os']['name'] == 'Ubuntu' and
+      versioncmp($facts['os']['release']['full'], '26.04') >= 0 {
+    file { '/etc/apparmor.d/local/ssh-keyscan':
+      ensure  => file,
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+      content => "r ${hostsfile},\n",
+      notify  => Exec['apparmor_reload_ssh-keyscan'],
+    }
+    exec { 'apparmor_reload_ssh-keyscan':
+      command     => 'apparmor_parser -r /etc/apparmor.d/ssh-keyscan',
+      refreshonly => true,
+      path        => ['/sbin', '/usr/sbin', '/usr/bin'],
+      onlyif      => 'test -f /etc/apparmor.d/ssh-keyscan',
+      before      => Exec['sunet_ssh-keyscan'],
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Ubuntu 26.04 ships an AppArmor profile for `ssh-keyscan` that restricts it to network access only, causing the keyscan to fail when reading the hosts file. Add a local override at `/etc/apparmor.d/local/ssh-keyscan` to permit reading the hosts file, and reload the profile before running the keyscan.