### PR TITLE
fix File.exists? -> File.exist? in tls_certificates.rb (Ruby 3.2 compat)

### DIFF
--- a/lib/facter/tls_certificates.rb
+++ b/lib/facter/tls_certificates.rb
@@ -13,7 +13,7 @@ Facter.add('tls_certificates') do
       if part == 'privkey'
         part = 'key'  # consistency with non-dehydrated certs
       end
-      if File.exists? partname
+      if File.exist? partname
         res[hostpart]['dehydrated_' + part] = partname
       else
         warn("Not found: #{partname}")


### PR DESCRIPTION
`File.exists?` was removed in Ruby 3.2. Replace with `File.exist?`.