### PR TITLE
apt/repo_docker: unify docker apt repo logic from dockerhost and dockerhost2

### DIFF
--- a/manifests/apt/repo_docker.pp
+++ b/manifests/apt/repo_docker.pp
@@ -8,7 +8,7 @@ define sunet::apt::repo_docker (
   $release   = $facts['os']['distro']['release']['major']
 
   if ($distro == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '24.04') < 0) or
-     ($distro == 'Debian' and versioncmp($release, '13') < 0) {
+    ($distro == 'Debian' and versioncmp($release, '13') < 0) {
     sunet::misc::create_dir { '/etc/cosmos/apt/keys': owner => 'root', group => 'root', mode => '0755'}
     file { '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub':
       ensure  => file,

--- a/manifests/apt/repo_docker.pp
+++ b/manifests/apt/repo_docker.pp
@@ -1,19 +1,55 @@
 # The apt repo for docker
 define sunet::apt::repo_docker (
+  Enum['stable', 'edge', 'test'] $docker_repo = 'stable',
 ) {
 
-  $distro = $facts['os']['distro']['id']
+  $distro    = $facts['os']['distro']['id']
   $lc_distro = downcase($distro)
+  $release   = $facts['os']['distro']['release']['major']
 
-  apt::source { 'docker':
-    location => "https://download.docker.com/linux/${lc_distro}",
-    repos    => 'stable',
-    key      => {
-      name    => 'docker.asc',
+  if ($distro == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '24.04') < 0) or
+     ($distro == 'Debian' and versioncmp($release, '13') < 0) {
+    sunet::misc::create_dir { '/etc/cosmos/apt/keys': owner => 'root', group => 'root', mode => '0755'}
+    file { '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub':
+      ensure  => file,
+      mode    => '0644',
       content => file('sunet/apt/docker.asc'),
-    },
-    notify   => Exec['dockerhost_apt_get_update'],
+    }
+    apt::key { 'docker_ce':
+      id     => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
+      server => 'https://does-not-exists-but-is-required.example.com',
+      source => '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub',
+      notify => Exec['dockerhost_apt_get_update'],
+    }
+    apt::source { 'docker_ce':
+      location => "https://download.docker.com/linux/${lc_distro}",
+      release  => $facts['os']['distro']['codename'],
+      repos    => $docker_repo,
+      key      => {'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'},
+      notify   => Exec['dockerhost_apt_get_update'],
+    }
+  } else {
+    # Ubuntu 24.04+ (apt 2.7+) and Debian 13+ removed apt-key support;
+    # use a signed-by keyring file instead.
+    file { '/etc/apt/keyrings':
+      ensure => directory,
+      mode   => '0755',
+    }
+    file { '/etc/apt/keyrings/docker.asc':
+      ensure  => file,
+      mode    => '0644',
+      content => file('sunet/apt/docker.asc'),
+      require => File['/etc/apt/keyrings'],
+    }
+    apt::source { 'docker':
+      location => "https://download.docker.com/linux/${lc_distro}",
+      repos    => $docker_repo,
+      keyring  => '/etc/apt/keyrings/docker.asc',
+      notify   => Exec['dockerhost_apt_get_update'],
+      require  => File['/etc/apt/keyrings/docker.asc'],
+    }
   }
+
   apt::pin { 'Pin docker repo':
     packages => '*',
     priority => 1,

--- a/manifests/dockerhost.pp
+++ b/manifests/dockerhost.pp
@@ -57,35 +57,6 @@ class sunet::dockerhost(
     }
   }
 
-  if versioncmp($facts['os']['release']['full'], '22.04') <= 0 or $facts['os']['name'] == 'Debian' {
-    # Remove old versions, if installed
-    package { ['lxc-docker-1.6.2', 'lxc-docker'] :
-      ensure => 'purged',
-    }
-
-    file {'/etc/apt/sources.list.d/docker.list':
-      ensure => 'absent',
-    }
-
-    if $docker_package_name != 'docker-engine' and $docker_package_name != 'docker.io' {
-      # transisition to docker-ce
-      exec { 'remove_dpkg_arch_i386':
-        command => '/usr/bin/dpkg --remove-architecture i386',
-        onlyif  => '/usr/bin/dpkg --print-foreign-architectures | grep i386',
-      }
-
-      package {'docker-engine': ensure => 'purged'}
-    }
-
-    # Clean up old pinning
-    file {'/etc/apt/preferences.d/docker-ce-cli.pref':
-      ensure => 'absent',
-    }
-    file {'/etc/apt/preferences.d/docker_package.pref':
-      ensure => 'absent',
-    }
-  }
-
   ensure_resource('sunet::apt::repo_docker', 'sunet-dockerhost-docker-repo', {'docker_repo' => $docker_repo})
 
   package { $docker_package_name :

--- a/manifests/dockerhost.pp
+++ b/manifests/dockerhost.pp
@@ -77,39 +77,6 @@ class sunet::dockerhost(
       package {'docker-engine': ensure => 'purged'}
     }
 
-    # Add the dockerproject repository, then force an apt-get update before
-    # trying to install the package. See https://tickets.puppetlabs.com/browse/MODULES-2190.
-    #
-    sunet::misc::create_dir { '/etc/cosmos/apt/keys': owner => 'root', group => 'root', mode => '0755'}
-    file {
-      '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub':
-        ensure  => file,
-        mode    => '0644',
-        content => file('sunet/apt/docker.asc'),
-        ;
-      }
-    apt::key { 'docker_ce':
-      id     => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
-      server => 'https://does-not-exists-but-is-required.example.com',
-      source => '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub',
-      notify => Exec['dockerhost_apt_get_update'],
-    }
-
-    $distro = downcase($facts['os']['name'])
-    # new source
-    apt::source {'docker_ce':
-      location => "https://download.docker.com/linux/${distro}",
-      release  => $facts['os']['distro']['codename'],
-      repos    => $docker_repo,
-      key      => {'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'},
-      notify   => Exec['dockerhost_apt_get_update'],
-    }
-
-    apt::pin { 'Pin docker repo':
-      packages => '*',
-      priority => 1,
-      origin   => 'download.docker.com'
-    }
     # Clean up old pinning
     file {'/etc/apt/preferences.d/docker-ce-cli.pref':
       ensure => 'absent',
@@ -117,15 +84,9 @@ class sunet::dockerhost(
     file {'/etc/apt/preferences.d/docker_package.pref':
       ensure => 'absent',
     }
-
-    exec { 'dockerhost_apt_get_update':
-      command     => '/usr/bin/apt-get update',
-      cwd         => '/tmp',
-      refreshonly => true,
-    }
-  } else {
-    ensure_resource('sunet::apt::repo_docker', 'sunet-dockerhost-docker-repo')
   }
+
+  ensure_resource('sunet::apt::repo_docker', 'sunet-dockerhost-docker-repo', {'docker_repo' => $docker_repo})
 
   package { $docker_package_name :
     ensure  => $docker_version,

--- a/manifests/dockerhost2.pp
+++ b/manifests/dockerhost2.pp
@@ -58,54 +58,7 @@ class sunet::dockerhost2(
       ;
   }
 
-  $distro = $facts['os']['distro']['id']
-  $lc_distro = downcase($distro)
-  $release = $facts['os']['distro']['release']['major']
-
-  if (
-    ($distro == 'Ubuntu' and versioncmp($release, '26') <= 0) or
-    ($distro == 'Debian' and versioncmp($release, '12') <= 0)
-  ) {
-    # Add the dockerproject repository, then force an apt-get update before
-    # trying to install the package. See https://tickets.puppetlabs.com/browse/MODULES-2190.
-    #
-    sunet::misc::create_dir { '/etc/cosmos/apt/keys': owner => 'root', group => 'root', mode => '0755'}
-    file {
-      '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub':
-        ensure  => file,
-        mode    => '0644',
-        content => file('sunet/apt/docker.asc'),
-        ;
-      }
-    apt::key { 'docker_ce':
-      id     => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
-      server => 'https://does-not-exists-but-is-required.example.com',
-      source => '/etc/cosmos/apt/keys/docker_ce-8D81803C0EBFCD88.pub',
-      notify => Exec['dockerhost_apt_get_update'],
-    }
-
-    # new source
-    apt::source {'docker_ce':
-      location => "https://download.docker.com/linux/${lc_distro}",
-      release  => $facts['os']['distro']['codename'],
-      repos    => $docker_repo,
-      key      => {'id' => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'},
-      notify   => Exec['dockerhost_apt_get_update'],
-    }
-
-    apt::pin { 'Pin docker repo':
-      packages => '*',
-      priority => 1,
-      origin   => 'download.docker.com'
-    }
-    exec { 'dockerhost_apt_get_update':
-      command     => '/usr/bin/apt-get update',
-      cwd         => '/tmp',
-      refreshonly => true,
-    }
-  } else {
-    ensure_resource('sunet::apt::repo_docker', 'sunet-dockerhost2-docker-repo')
-  }
+  ensure_resource('sunet::apt::repo_docker', 'sunet-dockerhost2-docker-repo', {'docker_repo' => $docker_repo})
 
   package { $docker_package_name :
     ensure  => $docker_version,


### PR DESCRIPTION
I've only tested this on a freshly installed 22.04, because of issues with garethr-docker on 26.04. I will adress that in a separate PR.

It isn't exactly clear to me what this apt/repo_docker.pp is intended to do, so I'm guessing that it should handle setting up APT for Docker. It doesn't make sense to me to leave handling of older versions of APT in dockerhost.pp/dockerhost2.pp then, but I might have misunderstood.

I guess you haven't tested dockerhost2.pp on any 24.04? That version should require signed-by keyring rather than apt::key, and I suspect dockerhost2.pp was broken for 24.04.

## Summary

`sunet::apt::repo_docker` previously only handled Ubuntu 24.04+ / Debian 13+ (keyring-based apt). This PR extends it to also cover the older `apt-key` path (Ubuntu < 24.04, Debian < 13), moving that logic out of `sunet::dockerhost` and `sunet::dockerhost2`.

- `sunet::dockerhost` and `sunet::dockerhost2` both had duplicated inline apt repo setup for older distros. Both now unconditionally delegate to `ensure_resource('sunet::apt::repo_docker', ...)`, passing through `$docker_repo`.
- `sunet::apt::repo_docker` gains a `$docker_repo` parameter (default `stable`) and a version branch: older distros get the `apt-key`/`apt::source` path with the cosmos keyfile; newer distros get the `signed-by` keyring path.
- The pre-docker-ce package/source cleanup in `sunet::dockerhost` (lxc-docker, docker-engine, old sources.list.d entry, i386 arch removal) is dropped — these hosts are long gone.