### PR TITLE
valkey tls improvements

### DIFF
--- a/templates/valkey/server.conf.erb
+++ b/templates/valkey/server.conf.erb
@@ -16,6 +16,11 @@ tls-port <%= @valkeyportnum %>
 tls-replication yes
 <% if @cluster %>
 tls-cluster yes
+# cluster-announce-port 0 - Explicitly disables advertising a non-TLS port
+cluster-announce-port 0
+cluster-announce-tls-port <%= @valkeyportnum %>
+# advertise the hostname instead of IP, this helps to avoid SAN missmatch from the clients when validating the cert
+cluster-announce-hostname <%= server_fqdn %>
 <% end %>
 tls-cert-file /cert/cert.pem
 tls-key-file /cert/privkey.pem

--- a/templates/valkey/server.conf.erb
+++ b/templates/valkey/server.conf.erb
@@ -20,7 +20,7 @@ tls-cluster yes
 cluster-announce-port 0
 cluster-announce-tls-port <%= @valkeyportnum %>
 # advertise the hostname instead of IP, this helps to avoid SAN missmatch from the clients when validating the cert
-cluster-announce-hostname <%= server_fqdn %>
+cluster-announce-hostname <%= @server_fqdn %>
 <% end %>
 tls-cert-file /cert/cert.pem
 tls-key-file /cert/privkey.pem


### PR DESCRIPTION
Improve TLS related settings for valkey
- Announce the hostname instead of IPs to help with SAN validation from connecting clients
- Disable advertisement of non-TLS port
- Explicitly announce the cluster TLS port (used by the connecting clients)