### PR TITLE
sunet-reinstall: wait for dehydrated instead of sleeping 150s

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -90,8 +90,7 @@ class sunet::server (
       content => template('sunet/kvm/sunet-reinstall.erb'),
     }
     sunet::scriptherder::cronjob { 'sunet_reinstall':
-      # sleep 150 to avoid running at the same time as the cronjob fetching new certificates
-      cmd           => "sh -c 'sleep 150; /usr/local/bin/sunet-reinstall -f'",
+      cmd           => '/usr/local/bin/sunet-reinstall -f',
       ok_criteria   => ['exit_status=0', 'max_age=25h'],
       warn_criteria => ['exit_status=0', 'max_age=49h'],
       special       => 'daily',

--- a/templates/kvm/sunet-reinstall.erb
+++ b/templates/kvm/sunet-reinstall.erb
@@ -10,6 +10,14 @@ if [ "x$1" = "x-f" ]; then
     shift
 fi
 
+# Wait up to 5 minutes for any running dehydrated cert renewal to finish
+n=30
+while [ $n -gt 0 ] && pgrep -f dehydrated >/dev/null 2>&1; do
+    echo "$0: waiting for dehydrated to finish ($n attempts left)"
+    sleep 10
+    n=$((n-1))
+done
+
 test -d /mnt/seed || mkdir /mnt/seed
 vdb_fail=0
 mount /dev/vdb /mnt/seed || vdb_fail=1


### PR DESCRIPTION
Replace the hardcoded `sleep 150` in the sunet-reinstall cronjob with an active wait loop that polls for a running `dehydrated` process (up to 5 minutes, 10s intervals).

This avoids the race without adding unnecessary delay on hosts where dehydrated finishes quickly or isn't running at all.