### PR TITLE
server: dmi guards and skip grub on Raspbian

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -83,7 +83,7 @@ class sunet::server (
     class { 'sunet::security::disable_all_local_users': }
   }
 
-  if $facts['is_virtual'] == true and $facts['dmi']['product']['name'] !~ /OpenStack\s(Compute|Nova)/ {
+  if $facts['is_virtual'] == true and (!$facts['dmi'] or $facts.dig('dmi', 'product', 'name') !~ /OpenStack\s(Compute|Nova)/) {
     file { '/usr/local/bin/sunet-reinstall':
       ensure  => file,
       mode    => '0755',
@@ -98,19 +98,20 @@ class sunet::server (
     }
   }
 
-  if $facts['dmi']['product']['name'] =~ /OpenStack\s(Compute|Nova)/ {
+  if $facts['dmi'] and $facts.dig('dmi', 'product', 'name') =~ /OpenStack\s(Compute|Nova)/ {
     class { 'sunet::iaas::server': }
   }
 
-  file { '/etc/default/grub.d/99-sunet-grub-menu.cfg':
-    ensure  => present,
-    content => file('sunet/server/99-sunet-grub-menu.cfg'),
-    notify  => Exec['sunet_server_update_grub'],
-
-  }
-  exec { 'sunet_server_update_grub':
-    command     => '/usr/sbin/update-grub',
-    refreshonly => true,
+  if $facts.dig('os', 'distro', 'id') != 'Raspbian' {
+    file { '/etc/default/grub.d/99-sunet-grub-menu.cfg':
+      ensure  => present,
+      content => file('sunet/server/99-sunet-grub-menu.cfg'),
+      notify  => Exec['sunet_server_update_grub'],
+    }
+    exec { 'sunet_server_update_grub':
+      command     => '/usr/sbin/update-grub',
+      refreshonly => true,
+    }
   }
 
 }


### PR DESCRIPTION
Guard all dmi fact access with `facts.dig()` / `!facts['dmi']` checks so Puppet doesn't abort on nodes without DMI data.

Skip grub config entirely on Raspbian (no grub installed). Use `os.distro.id` instead of `os.name` for the Raspbian check — `os.name` reports `'Debian'` on Raspbian, causing the guard to be ineffective.