### PR TITLE
kvm: bootstrap cosmos via systemd service on second boot

### DIFF
--- a/templates/kvm/user_data.erb
+++ b/templates/kvm/user_data.erb
@@ -2,11 +2,12 @@
 #
 # Docs: https://cloudinit.readthedocs.io/en/latest/ (this is Data source 'No Cloud')
 #
-user: root
+users:
+  - name: root
 <% if @password -%>
-password: <%= @password %>
+    passwd: <%= @password %>
 <% end -%>
-disable_root: 0
+disable_root: false
 chpasswd:
   expire: False
 ssh_pwauth: False
@@ -53,7 +54,6 @@ apt:
         - <%= @apt_mirror %>
         - http://archive.ubuntu.com
 <% end -%>
-package_update: true
 runcmd:
    - "echo '*** debug: interfaces:'"
    - "ifconfig -a"

--- a/templates/kvm/user_data.erb
+++ b/templates/kvm/user_data.erb
@@ -55,16 +55,19 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
-<% if @gateway6 -%>
-  - path: "/etc/netplan/60-disable_ra.yaml"
-    permissions: "0644"
+  - path: "/etc/netplan/60-cloud-init_user-data.yaml"
+    permissions: "0600"
     owner: "root"
     content: |
       network:
+        version: 2
         ethernets:
           eth0:
+            match:
+              macaddress: '<%= @mac %>'
+            set-name: 'eth0'
+<% if @gateway6 -%>
             accept-ra: false
-        version: 2
 <% end -%>
 <% if @local_size and @local_size != "0" -%>
 mounts:

--- a/templates/kvm/user_data.erb
+++ b/templates/kvm/user_data.erb
@@ -31,6 +31,30 @@ write_files:
     content: |
       # Enable grub on serial console
       GRUB_TERMINAL=serial
+  - path: "/etc/run-cosmos-at-boot"
+    permissions: "0644"
+    owner: "root"
+    content: ""
+  - path: "/etc/systemd/system/cosmos-bootstrap.service"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      [Unit]
+      Description=Bootstrap cosmos
+      After=network-online.target
+      Wants=network-online.target
+      ConditionPathExists=/etc/run-cosmos-at-boot
+
+      [Service]
+      Type=oneshot
+      ExecStart=/bin/bash -lc 'which cosmos || (cd /root && bash /root/bootstrap-cosmos.sh <%= @name %> <%= @repo %> <%= @tagpattern %>); cosmos -v update && cosmos -v apply && rm -f /etc/run-cosmos-at-boot'
+      SyslogIdentifier=cosmos-bootstrap
+      StandardOutput=journal+console
+      StandardError=journal+console
+      TimeoutStartSec=3600
+
+      [Install]
+      WantedBy=multi-user.target
 <% if @gateway6 -%>
   - path: "/etc/netplan/60-disable_ra.yaml"
     permissions: "0644"
@@ -69,5 +93,5 @@ runcmd:
    - "mount /dev/vdb /tmp/seed"
    - "cp /tmp/seed/bootstrap-cosmos.sh /tmp/seed/cosmos_*_all.deb /root"
    - "test -f /tmp/seed/sunet-reinstall.tgz && (echo 'Unpacking files from previous installation:'; cd /; tar zxvf /tmp/seed/sunet-reinstall.tgz)"
-   - "cd /root && /root/bootstrap-cosmos.sh <%= @name %> <%= @repo %> <%= @tagpattern %>"
-   - "bash -lc 'cosmos -v update && cosmos -v apply'"
+   - "systemctl enable cosmos-bootstrap.service"
+   - "reboot"


### PR DESCRIPTION
Three commits improving KVM cloud-init provisioning:

1. **Fix cloud-init schema warnings** — switch to `users` list with `passwd` key, `disable_root: false`, drop `package_update: true`.

2. **Bootstrap cosmos via systemd service** — write a `cosmos-bootstrap.service` unit via `write_files`, enable it, then reboot instead of running cosmos directly from `runcmd`. The reboot is needed in some situations (e.g. interface renames) and also fixes SSH server key restoration from `sunet-reinstall.tgz`. The service runs after `network-online.target` and removes the flag file on success, making bootstrapping idempotent — it retries on each reboot until finished.

3. **Rename NIC to eth0 via netplan** — replace the gateway6-conditional `60-disable_ra.yaml` with a permanent `60-cloud-init_user-data.yaml` that matches the NIC by MAC address and sets the name to `eth0`. The `accept-ra: false` setting is preserved inside the gateway6 conditional.