### PR TITLE
Fix exabgp fragments sort order with new puppet-concat

### DIFF
--- a/manifests/exabgp/config.pp
+++ b/manifests/exabgp/config.pp
@@ -13,14 +13,14 @@ define sunet::exabgp::config(
 
   concat::fragment { 'exabgp_header':
     target  => $config,
-    order   => '10000',
+    order   => '010',
     content => template('sunet/exabgp/exabgp.conf_header.erb'),
     #notify  => Service['exabgp'],
   }
 
   concat::fragment { 'exabgp_footer':
     target  => $config,
-    order   => '10',
+    order   => '200',
     content => template('sunet/exabgp/exabgp.conf_footer.erb'),
     #notify  => Service['exabgp'],
   }

--- a/manifests/lb/exabgp/config.pp
+++ b/manifests/lb/exabgp/config.pp
@@ -15,14 +15,14 @@ define sunet::lb::exabgp::config(
 
   concat::fragment { 'exabgp_header':
     target  => $config,
-    order   => '10000',
+    order   => '010',
     content => template('sunet/lb/exabgp/exabgp.conf_header.erb'),
     notify  => $notify,
   }
 
   concat::fragment { 'exabgp_footer':
     target  => $config,
-    order   => '10',
+    order   => '200',
     content => template('sunet/lb/exabgp/exabgp.conf_footer.erb'),
     notify  => $notify,
   }


### PR DESCRIPTION
The `exabgp_header` and `exabgp_footer` concat fragments had their order
values swapped (`header=10000`, `footer=10`), producing invalid config on
sites running a modern concat module (8+) which sorts numerically.

The fix uses zero-padded values (`'010'`, `'100'`, `'200'`) so that the
first character always differs. This makes lexicographic sort (old concat)
and numeric sort (concat 8+) agree on the correct order — both produce
header → neighbors → footer.

Tested on Ubuntu 22.04 (concat 2018, lexicographic sort) and Ubuntu 26.04
(concat 8.0.0, numeric sort).