### PR TITLE
ubuntu26 flatten fix

### DIFF
--- a/templates/dockerhost/daemon2.json.erb
+++ b/templates/dockerhost/daemon2.json.erb
@@ -14,7 +14,7 @@
     }
   ],
   <% if @docker_dns -%>
-  "dns": <%= scope.function_flatten([[@docker_dns]]) %>,
+  "dns": <%= [[@docker_dns]].flatten() %>,
   <% end -%>
   <% if @ipv6 -%>
   "fixed-cidr-v6": "<%= @docker_network_v6 -%>",


### PR DESCRIPTION
scope.flatten deprecated after puppet5

https://doc.wikimedia.org/puppet/puppet_functions_ruby3x/flatten.html
https://blog.x-way.org/Linux/2024/07/31/Puppet-ERB-array-flatten.html