### PR TITLE
Add cleanup of old docker apt repo

### DIFF
--- a/manifests/apt/repo_docker.pp
+++ b/manifests/apt/repo_docker.pp
@@ -31,6 +31,11 @@ define sunet::apt::repo_docker (
   } else {
     # Ubuntu 24.04+ (apt 2.7+) and Debian 13+ removed apt-key support;
     # use a signed-by keyring file instead.
+
+    # Clean up old repo to avoid Signed-By conflicts
+    file { '/etc/apt/sources.list.d/docker_ce.list':
+      ensure => absent,
+    }
     file { '/etc/apt/keyrings':
       ensure => directory,
       mode   => '0755',


### PR DESCRIPTION
We ran into this issue on existing servers:
`E: Conflicting values set for option Signed-By regarding source https://download.docker.com/linux/ubuntu/ noble: /etc/apt/keyrings/docker.asc != E: The list of sources could not be read.`
This is due to having 2 files for the docker repo: 
- `/etc/apt/sources.list.d/docker.list`
- `/etc/apt/sources.list.d/docker_ce.list`

So to fix this for existing servers we add a cleanup step.