### PR TITLE
scriptherder cleanup: quote name to please find

### DIFF
--- a/files/scriptherder/cleanup_scriptherder
+++ b/files/scriptherder/cleanup_scriptherder
@@ -55,7 +55,7 @@ def decide_days_to_save(interval):
 
 def remove_files(job_name, days_to_save):
     command = "find /var/cache/scriptherder -type f "
-    command += f"-mtime +{days_to_save} -name {job_name}__* "
+    command += f"-mtime +{days_to_save} -name \"{job_name}__*\" "
     command += "-delete"
     os.system(command)
 


### PR DESCRIPTION
example output before fix:

find: paths must precede expression:
`update_and_upgrade__ts-20260618T083001.902235_pid-3719781_output.data' find: possible unquoted pattern after predicate `-name'?