### PR TITLE
Make sure required resources exits

### DIFF
--- a/manifests/docker_run.pp
+++ b/manifests/docker_run.pp
@@ -80,6 +80,11 @@ define sunet::docker_run(
 
     if ($docker_class == 'sunet::dockerhost') {
 
+      # Ensure the custom docker network exists if needed
+      if $net != 'host' and $net != 'bridge' {
+        ensure_resource('docker_network', $net, { 'ensure' => 'present' })
+      }
+
       # If a non-default network is used, make sure it is created before this container starts
       $req = $net ? {
         'host'   => [],


### PR DESCRIPTION
Handle issue introduced in recent fix in dockerhost #483.

Error: Could not find resource 'Docker_network[docker]' in parameter 'require' (file: /etc/puppet/cosmos-modules/sunet/manifests/docker_run.pp, line: 101) on node dsmd-4.fidus.sunet.se