### PR TITLE
Fix dockerhost tcp bind host rendering

### DIFF
--- a/templates/dockerhost/service_override.conf.erb
+++ b/templates/dockerhost/service_override.conf.erb
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/dockerd<% unless @_docker_dns.nil? %> --dns=<%= @_docker_dns %><% end %><% unless @storage_driver.nil? %> --storage-driver=<%= @storage_driver %><% end %><% if @_extra_parameters and @_extra_parameters != '' %> <%= @_extra_parameters %><% end %><% unless @_tcp_bind.nil? %> --host=<%= @_tcp_bind %><% end %><% if @tls_enable %> --tls --tlscacert=<%= @tls_cacert %> --tlscert=<%= @tls_cert %> --tlskey=<%= @tls_key %><% end %>
+ExecStart=/usr/bin/dockerd<% unless @_docker_dns.nil? %> --dns=<%= @_docker_dns %><% end %><% unless @storage_driver.nil? %> --storage-driver=<%= @storage_driver %><% end %><% if @_extra_parameters and @_extra_parameters != '' %> <%= @_extra_parameters %><% end %> --host=fd://<% unless @_tcp_bind.nil? %><% Array(@_tcp_bind).each do |bind| %> --host=tcp://<%= bind %><% end %><% end %><% if @tls_enable %> --tls --tlscacert=<%= @tls_cacert %> --tlscert=<%= @tls_cert %> --tlskey=<%= @tls_key %><% end %>


### PR DESCRIPTION
dockerhost: fix tcp_bind rendering and restore fd:// socket
https://github.com/SUNET/puppet-sunet/commit/f37c07eb95b96755aa9abf4192cde516df5ad382 replaced the garethr-docker class with a hand-rolled
service_override.conf.erb whose ExecStart did `--host=<%= @_tcp_bind %>`.
@_tcp_bind is an Array, so ERB stringified it to `--host=["172.16.0.2:2376"]`,
which dockerd reads as a malformed IPv6 host and aborts with
"failed to lookup ... address in host specification". The template also
dropped the fd:// unix socket, so host-side `docker ps` hung.