### PR TITLE
scriptherder: random_sleep for cronjob, exclude param for monitoring

### DIFF
--- a/manifests/scriptherder/cronjob.pp
+++ b/manifests/scriptherder/cronjob.pp
@@ -15,6 +15,7 @@ define sunet::scriptherder::cronjob(
   Array[String[1]]          $ok_criteria   = ['exit_status=0'],
   Array[String[1]]          $warn_criteria = ['exit_status=0'],
   Boolean                   $purge_results = false,    # set to 'true' to remove job metadata files
+  Optional[Integer]         $random_sleep  = undef,
 ) {
   $safe_name = regsubst(pick($job_name, $title), '[^0-9A-Za-z._\-]', '_', 'G')
 
@@ -44,9 +45,13 @@ define sunet::scriptherder::cronjob(
     $_minute  = $minute
   }
 
+  $_command = $random_sleep ? {
+    undef   => "/usr/local/bin/scriptherder --mode wrap --syslog --name ${safe_name} -- ${cmd}",
+    default => "/usr/local/bin/scriptherder --mode wrap --syslog --random-sleep ${random_sleep} --name ${safe_name} -- ${cmd}",
+  }
   cron { $safe_name:
     ensure   => $ensure,
-    command  => "/usr/local/bin/scriptherder --mode wrap --syslog --name ${safe_name} -- ${cmd}",
+    command  => $_command,
     user     => $user,
     hour     => $_hour,
     minute   => $_minute,

--- a/manifests/scriptherder/monitoring.pp
+++ b/manifests/scriptherder/monitoring.pp
@@ -1,8 +1,14 @@
 # Configure Nagios monitoring of scriptherder jobs.
 # @param use_sudo  Run NRPE checks with sudo, if scriptherder umask prevents access to job files.
 class sunet::scriptherder::monitoring (
-  Boolean $use_sudo = true,
+  Boolean       $use_sudo = true,
+  Array[String] $exclude  = [],
 ) {
+  # used in nagios_nrpe_checks.erb and nagios_nrpe_checks_sudoers.erb
+  $scriptherder_check_cmd = $exclude ? {
+    []      => '/usr/local/bin/scriptherder --mode check',
+    default => "/usr/local/bin/scriptherder --mode check --exclude ${exclude.join(' ')}",
+  }
   if $::facts['sunet_has_nrpe_d'] == 'yes' {
     if $use_sudo {
       file {

--- a/templates/scriptherder/nagios_nrpe_checks.erb
+++ b/templates/scriptherder/nagios_nrpe_checks.erb
@@ -1,4 +1,4 @@
 # created by puppet
-command[check_scriptherder]=<% if @use_sudo -%>sudo <% end -%>/usr/local/bin/scriptherder --mode check
-command[check_scripts]=<% if @use_sudo -%>sudo <% end -%>/usr/local/bin/scriptherder --mode check
+command[check_scriptherder]=<% if @use_sudo -%>sudo <% end -%><%= @scriptherder_check_cmd %>
+command[check_scripts]=<% if @use_sudo -%>sudo <% end -%><%= @scriptherder_check_cmd %>
 command[check_cosmos]=<% if @use_sudo -%>sudo <% end -%>/usr/local/bin/scriptherder --mode check cosmos

--- a/templates/scriptherder/nagios_nrpe_checks_sudoers.erb
+++ b/templates/scriptherder/nagios_nrpe_checks_sudoers.erb
@@ -1,2 +1,2 @@
-nagios ALL=(root) NOPASSWD: /usr/local/bin/scriptherder --mode check
+nagios ALL=(root) NOPASSWD: <%= @scriptherder_check_cmd %>
 nagios ALL=(root) NOPASSWD: /usr/local/bin/scriptherder --mode check cosmos


### PR DESCRIPTION
## Summary

- `scriptherder::cronjob`: add `random_sleep` parameter to pass `--random-sleep N` to scriptherder, spreading cron job execution across a time window
- `scriptherder::monitoring`: add `exclude` array parameter to pass `--exclude` to the catch-all `check_scriptherder`/`check_scripts` NRPE commands; uses a canonical `$scriptherder_check_cmd` variable shared between the NRPE config and sudoers templates