### PR TITLE
Frontend improvements: route-adjust, docker compose v2, nftables, API enhancements

### DIFF
--- a/manifests/docker_compose_service.pp
+++ b/manifests/docker_compose_service.pp
@@ -15,8 +15,11 @@ define sunet::docker_compose_service(
     default => $service_name,
   }
 
-  $_template = $::facts['dockerhost2'] ? {
-    yes => 'sunet/dockerhost/compose2.service.erb',
+  $_use_compose2 = ($::facts['dockerhost2'] == 'yes') or
+    ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '26.04') >= 0)
+
+  $_template = $_use_compose2 ? {
+    true    => 'sunet/dockerhost/compose2.service.erb',
     default => 'sunet/dockerhost/compose.service.erb',
   }
 

--- a/manifests/docker_run.pp
+++ b/manifests/docker_run.pp
@@ -23,6 +23,7 @@ define sunet::docker_run(
   Hash[String, String] $extra_systemd_parameters = {},
   Boolean $uid_gid_consistency = true,
   Boolean $fetch_docker_image  = true,
+  Optional[String] $run_user   = undef,
 ) {
 
   $docker_class = $::facts['dockerhost2'] ? {

--- a/manifests/exabgp.pp
+++ b/manifests/exabgp.pp
@@ -1,10 +1,11 @@
 # exabgp
 define sunet::exabgp(
-  Array   $extra_arguments = [],
-  String  $config          = '/etc/bgp/exabgp.conf',
-  String  $version         = 'latest',
-  String  $volume          = '/etc/bgp',
-  Array   $docker_volumes  = [],
+  Array            $extra_arguments = [],
+  String           $config          = '/etc/bgp/exabgp.conf',
+  String           $version         = 'latest',
+  String           $volume          = '/etc/bgp',
+  Array            $docker_volumes  = [],
+  Optional[String] $run_user        = undef,
 ) {
   $safe_title = regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G');
   sunet::docker_run {"${safe_title}_exabgp":
@@ -12,7 +13,8 @@ define sunet::exabgp(
       imagetag => $version,
       volumes  => flatten(["${volume}:${volume}:ro", $docker_volumes]),
       net      => 'host',
-      command  => join(flatten([$config,$extra_arguments]),' ')
+      command  => join(flatten([$config,$extra_arguments]),' '),
+      run_user => $run_user,
   }
 
   sunet::snippets::no_icmp_redirects {"no_icmp_redirects_${safe_title}": }

--- a/manifests/frontend/api/instance.pp
+++ b/manifests/frontend/api/instance.pp
@@ -4,6 +4,7 @@ define sunet::frontend::api::instance(
   Integer       $api_port = 8080,
   Array[String] $backend_ips = [],
   String        $basedir = '/opt/frontend/api',
+  String        $group = 'sunetfrontend',
 ) {
 
   if $::facts['sunet_nftables_enabled'] != 'yes' {
@@ -17,7 +18,7 @@ define sunet::frontend::api::instance(
   # accept register requests from the servers
   ensure_resource('file', "${basedir}/backends/${site_name}", {
       ensure => 'directory',
-      group  => 'sunetfrontend',
+      group  => $group,
       mode   => '0770',
   })
 }

--- a/manifests/frontend/api/server.pp
+++ b/manifests/frontend/api/server.pp
@@ -1,16 +1,14 @@
 # Setup and run the API
 define sunet::frontend::api::server(
-  $username   = 'sunetfrontend',
-  $group      = 'sunetfrontend',
-  $basedir    = '/opt/frontend/api',
-  $docker_tag = 'latest',
+  $username                                     = 'sunetfrontend',
+  $group                                        = 'sunetfrontend',
+  $basedir                                      = '/opt/frontend/api',
+  $docker_tag                                   = 'latest',
+  Variant[String, Array[String]] $allow_clients = 'any',
+  Integer $port                                 = 8080,
+  Optional[String] $run_user                    = undef,
 )
 {
-  ensure_resource('sunet::system_user', $username, {
-    username => $username,
-    group    => $group,
-  })
-
   exec { 'api_mkdir':
     command => "/bin/mkdir -p ${basedir}",
     unless  => "/usr/bin/test -d ${basedir}",
@@ -18,20 +16,28 @@ define sunet::frontend::api::server(
 
   file {
     "${basedir}/backends":
-      ensure  => 'directory',
-      mode    => '0770',
-      group   => $group,
-      require => Sunet::System_user[$username],
+      ensure => 'directory',
+      mode   => '0770',
+      group  => $group,
       ;
   }
   sunet::docker_run { "${name}_api":
     image    => 'docker.sunet.se/sunetfrontend-api',
     imagetag => $docker_tag,
-    net      => 'host',
+    ports    => ["${port}:8080"],
     volumes  => ["${basedir}/backends:/backends",
                 '/dev/log:/dev/log',
                 '/var/log/sunetfrontend-api:/var/log/sunetfrontend-api',
                 ],
+    env      => ["runas_user=${username}", "runas_group=${group}"],
+    run_user => $run_user,
     require  => [File["${basedir}/backends"]],
+  }
+
+  # Internal port 8080 is hardcoded in the image's start.sh (--bind 0.0.0.0:8080) with no env var override.
+  # Docker maps $port -> 8080; docker_expose DNATs host-ns traffic to Docker's namespace at $port.
+  sunet::nftables::docker_expose { "${name}_api_port":
+    allow_clients => $allow_clients,
+    port          => $port,
   }
 }

--- a/manifests/frontend/load_balancer.pp
+++ b/manifests/frontend/load_balancer.pp
@@ -94,6 +94,7 @@ class sunet::frontend::load_balancer(
         basedir   => $basedir,
         confdir   => $confdir,
         scriptdir => $scriptdir,
+        api_group => 'fe-api',
       }
     }
 
@@ -114,6 +115,9 @@ class sunet::frontend::load_balancer(
     sunet::frontend::api::server { 'sunetfrontend':
       basedir    => $apidir,
       docker_tag => pick($config['load_balancer']['api_imagetag'], 'latest'),
+      username   => 'fe-api',
+      group      => 'fe-api',
+      run_user   => "${fe_api}:${fe_api}",
     }
 
     sunet::frontend::telegraf { 'frontend_telegraf':

--- a/manifests/frontend/load_balancer.pp
+++ b/manifests/frontend/load_balancer.pp
@@ -13,7 +13,20 @@ class sunet::frontend::load_balancer(
   Integer $haproxy     = $base_uidgid + 10,
   Integer $telegraf    = $base_uidgid + 11,
   Integer $varnish     = $base_uidgid + 12,
+  Integer $exabgp      = $base_uidgid + 20,
 ) {
+  # Set up users for running all services as non-root
+  class { 'sunet::frontend::load_balancer::users':
+    frontend   => $frontend,
+    fe_api     => $fe_api,
+    fe_monitor => $fe_monitor,
+    fe_config  => $fe_config,
+    haproxy    => $haproxy,
+    telegraf   => $telegraf,
+    varnish    => $varnish,
+    exabgp     => $exabgp,
+  }
+
   $config = lookup('sunet_frontend', undef, undef, undef)
   if $config =~ Hash[String, Hash] {
     $confdir = "${basedir}/config"
@@ -41,8 +54,37 @@ class sunet::frontend::load_balancer(
       file { '/etc/bgp/monitor':
         ensure  => file,
         mode    => '0755',
-        content => template('sunet/frontend/websites2_monitor.py.erb'),
+        content => template('sunet/frontend/exabgp_monitor.erb'),
         notify  => Sunet::Exabgp['load_balancer'],
+      }
+
+      ensure_resource('file', '/var/run/frontend-exabgp', { ensure => 'directory', owner => 'root', group => 'exabgp', mode => '0770' })
+      # /var/run is tmpfs — recreate with correct ownership before services start
+      file { '/etc/tmpfiles.d/frontend-exabgp.conf':
+        ensure  => file,
+        mode    => '0644',
+        content => "d /var/run/frontend-exabgp 0770 root exabgp - -\n",
+      }
+
+      file { '/usr/local/bin/frontend-route-adjust':
+        ensure  => file,
+        mode    => '0755',
+        content => template('sunet/frontend/frontend-route-adjust.erb'),
+      }
+      file { '/etc/systemd/system/frontend-route-adjust@.service':
+        ensure  => file,
+        mode    => '0644',
+        content => template('sunet/frontend/frontend-route-adjust.service.erb'),
+      }
+      file { '/etc/systemd/system/frontend-route-adjust-stop@.service':
+        ensure  => file,
+        mode    => '0644',
+        content => template('sunet/frontend/frontend-route-adjust-stop@.service.erb'),
+      }
+      file { '/etc/systemd/system/frontend-route-adjust@.path':
+        ensure  => file,
+        mode    => '0644',
+        content => template('sunet/frontend/frontend-route-adjust.path.erb'),
       }
 
       sunet::frontend::load_balancer::configure_peers { 'peers': router_id => $router_id, peers => $config['load_balancer']['peers'] }
@@ -62,9 +104,11 @@ class sunet::frontend::load_balancer(
     sunet::exabgp { 'load_balancer':
       docker_volumes => ["${basedir}/haproxy/scripts:${basedir}/haproxy/scripts:ro",
         '/opt/frontend/monitor:/opt/frontend/monitor:ro',
+        '/var/run/frontend-exabgp:/var/run/frontend-exabgp:rw',
         '/dev/log:/dev/log',
         ],
       version        => $exabgp_imagetag,
+      run_user       => "${exabgp}:${exabgp}",
     }
 
     sunet::frontend::api::server { 'sunetfrontend':
@@ -100,4 +144,3 @@ class sunet::frontend::load_balancer(
     fail('No/bad SUNET frontend load balancer config found in hiera')
   }
 }
-

--- a/manifests/frontend/load_balancer.pp
+++ b/manifests/frontend/load_balancer.pp
@@ -120,12 +120,13 @@ class sunet::frontend::load_balancer(
       run_user   => "${fe_api}:${fe_api}",
     }
 
+    $_statsd_addr = pick($facts.dig('networking', 'interfaces', 'docker0', 'ip'), '')
     sunet::frontend::telegraf { 'frontend_telegraf':
       docker_image          => pick($config['load_balancer']['telegraf_image'], 'docker.sunet.se/eduid/telegraf'),
       docker_imagetag       => pick($config['load_balancer']['telegraf_imagetag'], 'stable'),
       docker_volumes        => pick($config['load_balancer']['telegraf_volumes'], []),
       forward_url           => $config['load_balancer']['telegraf_forward_url'],
-      statsd_listen_address => pick($facts['networking']['interfaces']['docker0']['ip'], 'no-address-provided'),
+      statsd_listen_address => $_statsd_addr,
     }
 
     sunet::misc::ufw_allow { 'always-https-allow-http':

--- a/manifests/frontend/load_balancer/configure_websites2.pp
+++ b/manifests/frontend/load_balancer/configure_websites2.pp
@@ -1,12 +1,18 @@
 # website2
-define sunet::frontend::load_balancer::configure_websites2($websites, $basedir, $confdir, $scriptdir)
-{
+define sunet::frontend::load_balancer::configure_websites2(
+  $websites,
+  $basedir,
+  $confdir,
+  $scriptdir,
+  String $api_group = 'sunetfrontend',
+) {
   each($websites) | $site, $config | {
     create_resources('sunet::frontend::load_balancer::website2', {$site => {}}, {
       'basedir'         => $basedir,
       'confdir'         => $confdir,
       'scriptdir'       => $scriptdir,
       'config'          => $config,
+      'api_group'       => $api_group,
       })
   }
 }

--- a/manifests/frontend/load_balancer/peer.pp
+++ b/manifests/frontend/load_balancer/peer.pp
@@ -8,7 +8,7 @@ define sunet::frontend::load_balancer::peer(
 ) {
   # If $local_ip is not set, default to either $::ipaddress_default or $::ipaddress6_default
   # depending on the address family of $remote_ip
-  if ! is_ipaddr($local_ip) {
+  if $local_ip == undef or ! is_ipaddr($local_ip) {
     if is_ipaddr($remote_ip, 4) {
       $_local_ip = $facts['networking']['ip']
       $_local_ip_family = 4

--- a/manifests/frontend/load_balancer/users.pp
+++ b/manifests/frontend/load_balancer/users.pp
@@ -40,6 +40,7 @@ class sunet::frontend::load_balancer::users(
         'exabgp'     => undef,
         'fe-config'  => ['haproxy'],
         'fe-monitor' => ['haproxy'],
+        'fe-api'     => ['frontend', 'sunetfrontend'],
         default      => ['frontend'],
       }
     ensure_resource ( 'sunet::misc::system_user', $username, {

--- a/manifests/frontend/load_balancer/users.pp
+++ b/manifests/frontend/load_balancer/users.pp
@@ -12,16 +12,18 @@ class sunet::frontend::load_balancer::users(
   Integer $haproxy,
   Integer $telegraf,
   Integer $varnish,
+  Integer $exabgp,
 ) {
   # uid/gids looked up from compose files
   $user2uid = {
-    'frontend' => $frontend,
-    'fe-api' => $fe_api,
+    'frontend'   => $frontend,
+    'fe-api'     => $fe_api,
     'fe-monitor' => $fe_monitor,
-    'fe-config' => $fe_config,
-    'haproxy' => $haproxy,
-    'telegraf' => $telegraf,
-    'varnish' => $varnish,
+    'fe-config'  => $fe_config,
+    'haproxy'    => $haproxy,
+    'telegraf'   => $telegraf,
+    'varnish'    => $varnish,
+    'exabgp'     => $exabgp,
   }
 
   # Ensure this group is present before trying to add users fe-config and fe-monitor to it
@@ -35,6 +37,7 @@ class sunet::frontend::load_balancer::users(
     $groups = $username ? {
         'frontend'   => undef,
         'telegraf'   => undef,
+        'exabgp'     => undef,
         'fe-config'  => ['haproxy'],
         'fe-monitor' => ['haproxy'],
         default      => ['frontend'],

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -5,6 +5,7 @@ define sunet::frontend::load_balancer::website2(
   String  $scriptdir,
   Hash    $config,
   Integer $api_port = 8080,
+  String  $api_group = 'sunetfrontend',
 ) {
   $instance  = $name
   if length($instance) > 12 {
@@ -95,7 +96,7 @@ define sunet::frontend::load_balancer::website2(
   file {
     "${confdir}/${instance}/config.yml":
       ensure  => 'file',
-      group   => 'sunetfrontend',
+      group   => $api_group,
       mode    => '0640',
       force   => true,
       content => inline_template("# File created from Hiera by Puppet\n<%= @config4.to_yaml %>\n"),
@@ -214,6 +215,7 @@ define sunet::frontend::load_balancer::website2(
           site_name   => $site_name,
           backend_ips => $params['ips'],
           api_port    => $api_port,
+          group       => $api_group,
         }
       }
     }

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -115,7 +115,7 @@ define sunet::frontend::load_balancer::website2(
   $multinode_port         = pick_default($config['multinode_port'], false)
   $set_fqdn               = pick($config['set_fqdn'], false)
   $statsd_enabled         = pick($config['statsd_enabled'], true)
-  $statsd_host            = pick($facts['networking']['interfaces']['docker0']['ip'], $facts['networking']['ip'])
+  $statsd_host            = pick($facts.dig('networking', 'interfaces', 'docker0', 'ip'), $facts['networking']['ip'])
   $varnish_config         = pick($config['varnish_config'], '/opt/frontend/config/common/default.vcl')
   $varnish_enabled        = pick($config['varnish_enabled'], false)
   $varnish_image          = pick($config['varnish_image'], 'docker.sunet.se/library/varnish')
@@ -191,8 +191,17 @@ define sunet::frontend::load_balancer::website2(
       }
     }
   }
-  exec { "workaround_allow_forwarding_to_${instance}":
-    command => "/usr/sbin/ufw route allow out on br-${instance}",
+  if $::facts['sunet_nftables_enabled'] == 'yes' {
+    file { "/etc/nftables/conf.d/600-frontend_forward-${instance}.nft":
+      ensure  => file,
+      mode    => '0400',
+      content => "add rule inet filter forward oifname \"to_${instance}\" accept comment \"frontend forward to ${instance}\"\n",
+      notify  => Service['nftables'],
+    }
+  } else {
+    exec { "workaround_allow_forwarding_to_${instance}":
+      command => "/usr/sbin/ufw route allow out on br-${instance}",
+    }
   }
 
   if has_key($config, 'letsencrypt_server') and $config['letsencrypt_server'] != $facts['networking']['fqdn'] {

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -60,18 +60,25 @@ define sunet::frontend::load_balancer::website2(
 
   $local_config = lookup('sunet_frontend_local', undef, undef, {})
   $config4 = deep_merge($config3, $local_config)
-  ensure_resource('sunet::misc::create_dir', ["${confdir}/${instance}",
-                                              "${confdir}/${instance}/certs",
-                                              ], { owner => 'root', group => 'root', mode => '0700' })
+  ensure_resource('sunet::misc::create_dir', ["${confdir}/${instance}/certs"],
+                  { owner => 'root', group => 'root', mode => '0700' })
+  # Pre-create monitor dir so the systemd path unit can watch it before the monitor container starts
+  ensure_resource('sunet::misc::create_dir', ["${basedir}/monitor/${instance}"],
+                  { owner => 'root', group => 'root', mode => '0755' })
 
   # copy $tls_certificate_bundle to the instance 'certs' directory to detect when it is updated
   # so the service can be restarted
   $multi_certs = shell_split($tls_certificate_bundle).filter |String $cert| { $cert != 'crt' }
+  # Mirror sunet::docker_compose condition: only notify when Service will exist in catalog
+  # (on fresh install, to_docker doesn't exist yet so the service is not created)
+  $_nft_and_to_docker = $facts['sunet_nftables_enabled'] == 'yes' and has_key($facts['networking']['interfaces'], 'to_docker')
+  $_adv_or_nft_off = $facts['dockerhost_advanced_network'] == 'yes' or $facts['sunet_nftables_enabled'] == 'no'
+  $_notify_svc = if $_nft_and_to_docker or $_adv_or_nft_off { [Service["frontend-${instance}"]] } else { [] }
   if length($multi_certs) > 1 {
     $multi_certs.each |Integer $index, String $cert| {
       file { "${confdir}/${instance}/certs/tls_certificate_bundle.${index}.pem":
           source => $cert,
-          notify => Sunet::Docker_compose["frontend-${instance}"],
+          notify => $_notify_svc,
       }
     }
     file { "${confdir}/${instance}/certs/tls_certificate_bundle.pem":
@@ -80,7 +87,7 @@ define sunet::frontend::load_balancer::website2(
   } else {
     file { "${confdir}/${instance}/certs/tls_certificate_bundle.pem":
         source => $tls_certificate_bundle,
-        notify => Sunet::Docker_compose["frontend-${instance}"],
+        notify => $_notify_svc,
     }
 
   }
@@ -152,6 +159,22 @@ define sunet::frontend::load_balancer::website2(
     description      => "SUNET frontend instance ${instance} (site ${site_name})",
     start_command    => "/usr/local/bin/start-frontend ${_compose_bin_arg} ${basedir} ${name} ${confdir}/${instance}/docker-compose.yml",
     mode             => '0755',
+  }
+
+  service { "frontend-route-adjust@${instance}.service":
+    enable   => true,
+    provider => 'systemd',
+    require  => File['/etc/systemd/system/frontend-route-adjust@.service'],
+  }
+  service { "frontend-route-adjust@${instance}.path":
+    enable   => true,
+    provider => 'systemd',
+    require  => File['/etc/systemd/system/frontend-route-adjust@.path'],
+  }
+  service { "frontend-route-adjust-stop@${instance}.service":
+    enable   => true,
+    provider => 'systemd',
+    require  => File['/etc/systemd/system/frontend-route-adjust-stop@.service'],
   }
 
   if has_key($config, 'allow_ports') {

--- a/manifests/frontend/load_balancer/website2.pp
+++ b/manifests/frontend/load_balancer/website2.pp
@@ -138,6 +138,11 @@ define sunet::frontend::load_balancer::website2(
     content => template('sunet/frontend/frontend-config.erb'),
   })
 
+  $_compose_bin_arg = ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['full'], '26.04') >= 0) ? {
+    true    => '--compose_bin /usr/bin/docker',
+    default => '',
+  }
+
   sunet::docker_compose { "frontend-${instance}":
     content          => template('sunet/frontend/docker-compose_template.erb'),
     service_prefix   => 'frontend',
@@ -145,7 +150,8 @@ define sunet::frontend::load_balancer::website2(
     compose_dir      => $confdir,
     compose_filename => 'docker-compose.yml',
     description      => "SUNET frontend instance ${instance} (site ${site_name})",
-    start_command    => "/usr/local/bin/start-frontend ${basedir} ${name} ${confdir}/${instance}/docker-compose.yml",
+    start_command    => "/usr/local/bin/start-frontend ${_compose_bin_arg} ${basedir} ${name} ${confdir}/${instance}/docker-compose.yml",
+    mode             => '0755',
   }
 
   if has_key($config, 'allow_ports') {

--- a/templates/dockerhost/docker-compose.yml.erb
+++ b/templates/dockerhost/docker-compose.yml.erb
@@ -39,6 +39,12 @@ services:
       - <%= single_env %>
 <% end -%>
 <% end -%>
+<% if @run_user -%>
+    user: "<%= @run_user %>"
+<% end -%>
+<% if @net == 'host' or @net == 'bridge' -%>
+    network_mode: "<%= @net %>"
+<% else -%>
     networks:
       - <%= @net %>
 <% if @command -%>

--- a/templates/frontend/configure-container-network.erb
+++ b/templates/frontend/configure-container-network.erb
@@ -29,12 +29,13 @@ fi
 
 MATCHNAME="${INSTANCE}_haproxy_1"
 MATCHNAME2="${INSTANCE}_haproxy_run_1"
+MATCHNAME3="${INSTANCE}-haproxy-1"
+MATCHNAME4="${INSTANCE}-haproxy-run-1"
 
 num_tries=60
 for retry in $(seq ${num_tries}); do
-    # Check for two names to handle more eventualities of how the instances are launced with docker-compose
-    # (docker-compose up results in instance_haproxy_1, docker-compose run haproxy results in instance_haproxy_run_1)
-    DOCKEROUT=$(docker ps --format='{{ .ID }}:{{ .Names }}' | grep -e ":${MATCHNAME}$" -e ":${MATCHNAME2}$" )
+    # Check for multiple names to handle docker-compose v1 (underscores) and v2 (dashes)
+    DOCKEROUT=$(docker ps --format='{{ .ID }}:{{ .Names }}' | grep -e ":${MATCHNAME}$" -e ":${MATCHNAME2}$" -e ":${MATCHNAME3}$" -e ":${MATCHNAME4}$" )
     if [[ $DOCKEROUT ]]; then
 	DOCKERID=$(echo $DOCKEROUT | cut -d : -f 1)
 	CONTAINER=$(echo $DOCKEROUT | cut -d : -f 2)
@@ -43,12 +44,12 @@ for retry in $(seq ${num_tries}); do
 	    break
 	fi
     fi
-    echo "$0: Container ${MATCHNAME}/${MATCHNAME2} not found (attempt ${retry}/${num_tries})"
+    echo "$0: Container ${MATCHNAME}/${MATCHNAME2}/${MATCHNAME3}/${MATCHNAME4} not found (attempt ${retry}/${num_tries})"
     sleep 2
 done
 
 if [[ ! $DOCKERPID || $DOCKERPID == 0 ]]; then
-    echo "$0: Could not find PID of docker container ${MATCHNAME}/${MATCHNAME2}"
+    echo "$0: Could not find PID of docker container ${MATCHNAME}/${MATCHNAME2}/${MATCHNAME3}/${MATCHNAME4}"
     exit 1
 fi
 
@@ -60,7 +61,7 @@ ln -s /proc/${NSPID}/ns/net /var/run/netns/${INSTANCE}
 
 echo "Container ${CONTAINER}/${DOCKERID} has pid ${DOCKERPID} - symlinking /var/run/netns/${INSTANCE} to /proc/${NSPID}/ns/net"
 
-VETHHOST="${INSTANCE}"
+VETHHOST="to_${INSTANCE}"
 VETHCONTAINER="ve1${INSTANCE}"
 
 # Enable IPv6 forwarding. Should ideally be done more selectively, but...
@@ -69,23 +70,67 @@ sysctl net.ipv6.conf.all.forwarding=1
 set -x
 
 # Add a pair of virtual ethernet interfaces (think of them as a virtual cross-over ethernet cable)
-ip link del ${VETHHOST}
-ip link add name ${VETHHOST} mtu 1500 type veth peer name ${VETHCONTAINER} mtu 1500
-ip link set ${VETHHOST} master br-${INSTANCE}
-ip link set ${VETHHOST} up
+ip link del "${VETHHOST}"
+ip link add name "${VETHHOST}" mtu 1500 type veth peer name "${VETHCONTAINER}" mtu 1500
+if [ -f /var/run/netns/docker ]; then
+    # move VETHCONTAINER into the docker namespace and attach it to the bridge for this instance
+    ip link set "${VETHCONTAINER}" netns docker
+    ip -n docker link set "${VETHCONTAINER}" master "br-${INSTANCE}"
+else
+    ip link set "${VETHCONTAINER}" master "br-${INSTANCE}"
+fi
+ip link set "${VETHHOST}" up
 
+echo ""
+echo ""
+echo ""
 echo "$0: Network namespace and process diagnostics:"
 pgrep -a --ns "${DOCKERPID}"
 ip link show "${VETHHOST}"
-ip link show "${VETHCONTAINER}"
-ip link show "br-${INSTANCE}"
 
-# Move one end of the virtual ethernet cable inside the network namespace of the docker container
-ip link set "${VETHCONTAINER}" netns "${INSTANCE}" || {
-    echo "$0: FAILED to configure namespace, did ${CONTAINER} (pid ${DOCKERPID}) die?"
-    exit 1
-}
-ip netns exec "${INSTANCE}" ip link set "${VETHCONTAINER}" name sarimner0
+if [ -f /var/run/netns/docker ]; then
+    echo ""
+    echo ""
+    echo ""
+    echo "$0: Inside the docker namespace"
+    ip -n docker link show "${VETHCONTAINER}"
+    ip -n docker link show "br-${INSTANCE}"
+else
+    echo ""
+    echo ""
+    echo ""
+    echo "$0: In the host namespace"
+    ip link show "${VETHCONTAINER}"
+    ip link show "br-${INSTANCE}"
+fi
+
+echo ""
+echo ""
+echo ""
+echo "$0: Inside the instance namespace"
+ip -n "${INSTANCE}" link show "${VETHCONTAINER}"
+#ip -n "${INSTANCE}" link show "br-${INSTANCE}"
+
+if [ -f /var/run/netns/docker ]; then
+    # Move one end of the virtual ethernet cable from the docker namespace into the container namespace
+    ip -n docker link set "${VETHCONTAINER}" netns "${INSTANCE}" || {
+	echo "$0: FAILED to configure namespace, did ${CONTAINER} (pid ${DOCKERPID}) die?"
+	exit 1
+    }
+else
+    # Move one end of the virtual ethernet cable inside the network namespace of the docker container
+    ip link set "${VETHCONTAINER}" netns "${INSTANCE}" || {
+	echo "$0: FAILED to configure namespace, did ${CONTAINER} (pid ${DOCKERPID}) die?"
+	exit 1
+    }
+fi
+
+echo ""
+echo ""
+echo ""
+echo "$0: Renaming interface ${VETHCONTAINER} in the instance to sarimner0"
+# Rename interface inside container to sarimner0
+ip -n "${INSTANCE}" link set "${VETHCONTAINER}" name sarimner0
 
 # Docker likes to disable IPv6
 ip netns exec "${INSTANCE}" sysctl net.ipv6.conf.sarimner0.disable_ipv6=0
@@ -97,22 +142,89 @@ ip netns exec "${INSTANCE}" sysctl net.ipv6.conf.sarimner0.accept_dad=0
 # ip netns exec ${INSTANCE} sysctl net.ipv4.ip_nonlocal_bind=1
 # ip netns exec ${INSTANCE} sysctl net.ipv6.ip_nonlocal_bind=1
 
-
+echo ""
+echo ""
+echo ""
+echo "$0: Adding routing from host to the outside of the veth cable (${VETHHOST})"
 # Add IP addresses to the network namespace of the docker container
 for IP in $("${SCRIPTSDIR}"/frontend-config --instance "${INSTANCE}" print_ips); do
-    ip netns exec "${INSTANCE}" ip addr add "${IP}" dev sarimner0
-    ip route add "${IP}" dev br-"${INSTANCE}"
+    # The anycasted addresses are not suitable for use for outgoing connections. We can send packets
+    # just fine, but the responses may get routed to another frontend node. Therefore, we 'deprecate'
+    # them by setting preferred_lft to zero.
+    ip -n "${INSTANCE}" addr add "${IP}" dev sarimner0 preferred_lft 0
+    # VIP routes are managed by frontend-route-adjust based on backend health
 done
 
-ip netns exec "${INSTANCE}" ip link set sarimner0 up
+echo ""
+echo ""
+echo ""
+echo "$0: Bringing sarimner0 online, signalling the haproxy startup to commence"
+ip -n "${INSTANCE}" link set sarimner0 up
 
+# Set up routing for return traffic to the anycasted IPv4 addresses out through the sarimner0 inteface,
+# rather than to the Docker network namespace where it will be dropped.
+#
+# This requires source address based routing, fairly easy to do in a namespace fortunately.
+host_main_if=$(ip -4 route list | grep ^default | awk '{print $5}')
+v4gw=$(ip -4 -o addr list "${host_main_if}" | awk '{print $4}' | head -1 | awk -F / '{print $1}')
+v6gw=$(ip -6 -o addr list "${VETHHOST}" | awk '{print $4}' | head -1 | awk -F / '{print $1}')
+
+if [[ $v4gw ]]; then
+    ip -n "${INSTANCE}" -4 route add "${v4gw}" dev sarimner0 table 234
+    ip -n "${INSTANCE}" -4 route add default via "${v4gw}" dev sarimner0 table 234
+fi
+if [[ $v6gw ]]; then
+    ip -n "${INSTANCE}" -6 route add "${v6gw}" dev sarimner0 table 234
+    ip -n "${INSTANCE}" -6 route add default via "${v6gw}" dev sarimner0 table 234
+fi
+
+for IP in $("${SCRIPTSDIR}"/frontend-config --instance "${INSTANCE}" print_ips); do
+    if [[ $IP == *:* ]]; then
+        ip -n "${INSTANCE}" -6 rule add from "${IP}" table 234 prio 1
+    else
+        ip -n "${INSTANCE}" -4 rule add from "${IP}" table 234 prio 1
+    fi
+done
 
 # Set up IPv6 routing back out of the container, now that the interface is up.
 
 #sysctl net.ipv6.conf.${VETHHOST}.accept_dad=0
-v6gw=$(ip -6 addr list "br-${INSTANCE}" | awk '/inet6/{print $2}' | head -1 | awk -F / '{print $1}')
 if [[ $v6gw ]]; then
-    ip netns exec "${INSTANCE}" ip -6 route add default via "${v6gw}" dev sarimner0
+    ip -n "${INSTANCE}" -6 route add default via "${v6gw}" dev sarimner0
 else
     echo "$0: Can't set up IPv6 routing from container, device ${VETHHOST} has no IPv6 address"
 fi
+
+# Now add one more IPv6 address to sarimner0, within a prefix we can NAT suitably for
+# haproxy to be able to reach backends/acme-c etc. using IPv6
+extra_addr=$(ip -n "${INSTANCE}" -o addr show dev sarimner0 scope link | \
+    awk '{print $4'} | sed -e 's/^....::\(.*\)/fd0c::\1/')
+if [[ $extra_addr ]]; then
+    ip -n "${INSTANCE}" addr add "${extra_addr}" dev sarimner0
+    only_addr=$(echo ${extra_addr} | cut -d / -f 1)  # add host route, not with /64
+    ip route add "${only_addr}" dev "${VETHHOST}"
+else
+    echo "$0: Can't set up a IPv6 address for outgoing traffic from container, no link-local address found"
+fi
+
+echo ""
+echo ""
+echo ""
+echo "$0: Routing rules inside the instance namespace"
+ip -n "${INSTANCE}" -4 rule list
+ip -n "${INSTANCE}" -6 rule list
+echo ""
+echo ""
+echo ""
+echo "$0: General routes inside the instance namespace"
+ip -n "${INSTANCE}" -4 route list
+ip -n "${INSTANCE}" -6 route list
+echo ""
+echo ""
+echo ""
+echo "$0: Routes for the anycasted addresses inside the instance namespace"
+ip -n "${INSTANCE}" -4 route list table 234
+ip -n "${INSTANCE}" -6 route list table 234
+echo ""
+echo ""
+echo ""

--- a/templates/frontend/docker-compose_template.erb
+++ b/templates/frontend/docker-compose_template.erb
@@ -18,7 +18,7 @@ services:
       - '/dev/log:/dev/log'
       - '/opt/frontend/scripts/haproxy-start.sh:/haproxy-start.sh:ro'
       - 'haproxy_data:/etc/haproxy'
-      - 'haproxy_control:/var/run/haproxy-control'
+      - 'haproxy_control:/haproxy_control'
 <% if @multi_certs.is_a? Array and @multi_certs.size > 1 -%>
 <%- index = 0 -%>
 <% @multi_certs.each do |cert| -%>
@@ -104,11 +104,11 @@ services:
       - /opt/frontend/config/common:/opt/frontend/config/common:ro
       - /opt/frontend/config/<%= @instance %>:/opt/frontend/config/<%= @instance %>:ro
       - /opt/frontend/monitor/<%= @instance %>:/opt/frontend/monitor/<%= @instance %>:rw
-      - haproxy_control:/var/run/haproxy-control
+      - haproxy_control:/haproxy_control
     command: >
         /opt/frontend/scripts/monitor-haproxy
             <% if @statsd_enabled == true -%>--statsd_host <%= @statsd_host %> --statsd_prefix sarimner.<%= @instance %><% end -%>
-            --stats_url /var/run/haproxy-control/stats
+            --stats_url /haproxy_control/stats
             'site=<%= @site_name %>;group=default'
 <% if @dns.is_a? Array and @dns.size > 0 -%>
     dns:
@@ -117,9 +117,10 @@ services:
 <% end -%>
 <% end -%>
     environment:
-      - 'HOSTFQDN=<%= @fqdn %>'
+      - 'HOSTFQDN=<%= @facts['networking']['fqdn'] %>'
       - 'INSTANCE=<%= @instance %>'
       - 'SITENAME=<%= @site_name %>'
+      - 'STATSSOCKET=/haproxy_control/stats'
 
 volumes:
   haproxy_data:

--- a/templates/frontend/exabgp_monitor.erb
+++ b/templates/frontend/exabgp_monitor.erb
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Exabgp monitor process: creates the command FIFO, pushes initial route state from
+# existing announce files, then relays ongoing route updates to exabgp via stdout.
+# Run by exabgp as its process monitor inside the exabgp container.
+#
+# frontend-route-adjust@<instance> services watch for changes to the announce files
+# and write route add/withdraw commands to the write end of the FIFO.
+
+fifo=/var/run/frontend-exabgp/exabgp-commands
+mkdir -p "$(dirname "$fifo")"
+rm -f "$fifo"
+mkfifo -m 0600 "$fifo"
+
+# Push current state from all existing announce files so exabgp has initial state
+for f in /opt/frontend/monitor/*/announce; do
+    [[ -f "$f" ]] && cat "$f"
+done
+
+# Block-read FIFO for updates from frontend-route-adjust, relay to exabgp stdout.
+# exec 3<>$fifo holds the write end open so cat never gets EOF between writes.
+exec 3<>"$fifo"
+cat <&3

--- a/templates/frontend/frontend-route-adjust-stop@.service.erb
+++ b/templates/frontend/frontend-route-adjust-stop@.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=Withdraw VIP routes and BGP announcements on frontend %i stop
+PartOf=frontend-%i.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecStop=/usr/local/bin/frontend-route-adjust %i stop
+
+[Install]
+WantedBy=frontend-%i.service

--- a/templates/frontend/frontend-route-adjust.erb
+++ b/templates/frontend/frontend-route-adjust.erb
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -u
+
+INSTANCE=${1:?Usage: $0 <instance> [stop]}
+MODE=${2:-run}
+ANNOUNCE=/opt/frontend/monitor/$INSTANCE/announce
+FIFO=/var/run/frontend-exabgp/exabgp-commands
+
+log() { echo "frontend-route-adjust[$INSTANCE]: $*"; }
+
+fifo_write() {
+    if [[ ! -p "$FIFO" ]]; then
+        log "FIFO $FIFO not present, skipping BGP update"
+        return 0
+    fi
+    timeout 5 tee "$FIFO" > /dev/null || log "WARNING: FIFO write timed out or failed"
+}
+
+route_cmd() {
+    local action=$1 prefix=$2 ip=${prefix%%/*}
+    log "route $action $prefix"
+    if [[ $ip == *:* ]]; then
+        ip -6 route "$action" "$prefix" dev "to_$INSTANCE" 2>/dev/null || true
+    else
+        ip route "$action" "$prefix" dev "to_$INSTANCE" 2>/dev/null || true
+    fi
+}
+
+route_del_all() {
+    ip    route show dev "to_$INSTANCE" 2>/dev/null | awk '/^[0-9]/{print $1}'   | \
+        while read -r p; do route_cmd del "$p"; done
+    ip -6 route show dev "to_$INSTANCE" 2>/dev/null | awk '/^[0-9a-f]/{print $1}' | \
+        while read -r p; do route_cmd del "$p"; done
+}
+
+prefixes() {
+    awk '/^(announce|withdraw) route / { print $3 }' "$ANNOUNCE" 2>/dev/null | sort -u
+}
+
+if [[ $MODE == stop ]]; then
+    log "stopping: withdrawing BGP announcements and removing kernel routes"
+    if [[ -f "$ANNOUNCE" ]]; then
+        sed 's/^announce /withdraw /' "$ANNOUNCE" | fifo_write
+    fi
+    route_del_all
+    exit 0
+fi
+
+if [[ -f "$ANNOUNCE" ]]; then
+    if grep -q '^announce' "$ANNOUNCE"; then
+        log "healthy: adding routes and announcing to BGP"
+        fifo_write < "$ANNOUNCE"
+        while read -r prefix; do route_cmd replace "$prefix"; done < <(prefixes)
+    else
+        log "unhealthy: removing routes and withdrawing from BGP"
+        fifo_write < "$ANNOUNCE"
+        route_del_all
+    fi
+else
+    log "no announce file yet, removing any existing routes"
+    route_del_all
+fi

--- a/templates/frontend/frontend-route-adjust.path.erb
+++ b/templates/frontend/frontend-route-adjust.path.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Watch %i announce file for VIP route and BGP adjustments
+BindsTo=frontend-%i.service
+
+[Path]
+PathChanged=/opt/frontend/monitor/%i/announce
+Unit=frontend-route-adjust@%i.service
+
+[Install]
+WantedBy=frontend-%i.service

--- a/templates/frontend/frontend-route-adjust.service.erb
+++ b/templates/frontend/frontend-route-adjust.service.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Adjust VIP routes and BGP announcements for frontend %i
+After=frontend-%i.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/frontend-route-adjust %i
+
+[Install]
+WantedBy=frontend-%i.service

--- a/templates/frontend/start-frontend.erb
+++ b/templates/frontend/start-frontend.erb
@@ -76,7 +76,6 @@ import os
 import sys
 from fcntl import LOCK_EX, LOCK_NB
 from logging.handlers import SysLogHandler
-from multiprocessing import Process, Queue
 
 import argparse
 import datetime
@@ -170,11 +169,23 @@ def get_logger(myname, args, logger_in=None):
     return logger
 
 
-def manager_process(script, args, q, logger):
+def manager_process(script, args, write_fd, logger):
     """
     This is the child process that will acquire the exclusive lock, signal the parent
     to start docker-compose, initialise the container networking and then release the lock.
+
+    Double-forks immediately: the intermediate child (direct child of start-frontend)
+    exits right away so the parent can reap it via waitpid before execv. The grandchild
+    does the real work and is reparented to PID 1, so it is reaped by init on exit
+    rather than accumulating as a zombie under docker-compose.
     """
+    # Double-fork: grandchild does the work; this process exits immediately
+    if os.fork() > 0:
+        os._exit(0)
+
+    # Grandchild: detach from parent's session
+    os.setsid()
+
     logger.debug('Starting manager process for frontend instance {!r}'.format(args.name))
     retry = args.lock_retry
     with open(args.lockfile, 'w') as lock_fd:
@@ -195,11 +206,13 @@ def manager_process(script, args, q, logger):
                     ))
             if not locked and not retry:
                 logger.error('Failed to acquire lock in {} seconds - exiting'.format(args.lock_retry))
-                q.put('exit')
-                return False
+                os.write(write_fd, b'exit\n')
+                os.close(write_fd)
+                sys.exit(1)
 
         logger.info('Lock acquired (frontend instance {!r})'.format(args.name))
-        q.put('compose_up')
+        os.write(write_fd, b'compose_up\n')
+        os.close(write_fd)
 
         logger.info('Sleeping three seconds')
         time.sleep(3)
@@ -210,10 +223,7 @@ def manager_process(script, args, q, logger):
         logger.info('Frontend instance {!r} network configured in {:.2f} seconds'.format(
             args.name, (t2 - t1).total_seconds()))
         logger.debug('Network configuration script result: {}'.format(res))
-        q.put('exit')
     logger.info('Releasing lock and exiting (frontend instance {!r} finished)'.format(args.name))
-    # avoid becoming a zombie process in case the parent process has execv:d docker-compose
-    os.setsid()
     sys.exit(0)
 
 
@@ -228,29 +238,42 @@ def main(myname='start-frontend', args=None, logger_in=None):
         logger.error('Incorrect basedir, {} not found'.format(script))
         return False
 
-    q = Queue()
-    p = Process(target=manager_process, args=(script, args, q, logger.getChild('manager'),))
-    p.start()
-    logger.debug('Started process {}'.format(p))
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(read_fd)
+        manager_process(script, args, write_fd, logger.getChild('manager'))
+        os._exit(0)
 
-    while True:
-        logger.debug('Waiting for commands from the manager process...')
-        cmd = q.get()
-        logger.debug('Got command {!r}'.format(cmd))
-        if cmd == 'compose_up':
-            logger.info('Starting frontend instance {!r}'.format(args.name))
-            os.execv(args.compose_bin, [args.compose_bin,
-                                        '-f', args.compose_file,
-                                        'up',
-                                        '--force-recreate',
-                                        '--no-deps',
-                                        ])
-        elif cmd == 'exit':
-            logger.info('Received exit command')
-            return True
+    # Parent: close write end, wait for intermediate child to exit (it double-forks
+    # and calls os._exit immediately, so this returns almost instantly)
+    os.close(write_fd)
+    os.waitpid(pid, 0)
+
+    logger.debug('Waiting for command from the manager process...')
+    reader = os.fdopen(read_fd, 'r')
+    cmd = reader.readline().strip()
+    reader.close()
+    logger.debug('Got command {!r}'.format(cmd))
+
+    if cmd == 'compose_up':
+        logger.info('Starting frontend instance {!r}'.format(args.name))
+        # 'docker compose' (v2 plugin) needs 'compose' as first argument
+        if os.path.basename(args.compose_bin) == 'docker':
+            compose_argv = [args.compose_bin, 'compose',
+                            '-f', args.compose_file,
+                            'up', '--force-recreate', '--no-deps']
         else:
-            logger.info('Received command {!r} - exiting'.format(cmd))
-            return False
+            compose_argv = [args.compose_bin,
+                            '-f', args.compose_file,
+                            'up', '--force-recreate', '--no-deps']
+        os.execv(args.compose_bin, compose_argv)
+    elif cmd == 'exit':
+        logger.info('Received exit command')
+        return True
+    else:
+        logger.info('Received command {!r} - exiting'.format(cmd))
+        return False
 
 
 if __name__ == '__main__':

--- a/templates/frontend/websites2_monitor.py.erb
+++ b/templates/frontend/websites2_monitor.py.erb
@@ -52,6 +52,7 @@ import argparse
 
 import logging.handlers
 import inotify.adapters
+import inotify.calls
 from inotify.constants import IN_MOVED_TO, IN_CREATE, IN_DELETE
 
 
@@ -211,25 +212,50 @@ class InstanceDir(object):
                 self._logger.warning('{}: Scheduled poll detected unexpected changes'.format(self))
 
 
+def _try_add_watch(i, path, mask, logger):
+    """Add an inotify watch, returning False on failure (e.g. broken inotify on newer kernels)."""
+    try:
+        i.add_watch(path, mask=mask)
+        return True
+    except inotify.calls.InotifyError as e:
+        logger.warning('inotify add_watch failed for {}: {} - falling back to poll-only'.format(path, e))
+        return False
+
+
 def main(args, logger):
     i = inotify.adapters.Inotify()
     dirs = {}
+    inotify_ok = True
 
     mask = (IN_MOVED_TO | IN_CREATE | IN_DELETE)
 
     # Monitor the top level directory to detect added/removed instances
-    i.add_watch(args.monitor_dir, mask=mask)
+    if not _try_add_watch(i, args.monitor_dir, mask, logger):
+        inotify_ok = False
 
     # Add a monitor for each instance in the top level directory
     for this in os.listdir(args.monitor_dir):
         dir = os.path.join(args.monitor_dir, this)
         if os.path.isdir(dir):
-            i.add_watch(dir, mask=mask)
+            if inotify_ok:
+                _try_add_watch(i, dir, mask, logger)
             _timeout = args.timeout + (random.random() * 5) - 2.5  # spread polling intervals
             dirs[dir] = InstanceDir(dir,  _timeout, logger)
             logger.debug('Startup added instance {!s}'.format(dirs[dir]))
 
-    logger.info('Waiting for inotify events under {}'.format(args.monitor_dir))
+    if inotify_ok:
+        logger.info('Waiting for inotify events under {}'.format(args.monitor_dir))
+    else:
+        logger.warning('inotify unavailable, running in poll-only mode (timeout={}s)'.format(args.timeout))
+
+    if not inotify_ok:
+        # inotify broken - pure polling loop
+        while True:
+            now = time.time()
+            for dir in dirs.values():
+                dir.poll(now)
+            time.sleep(5)
+        return True
 
     for event in i.event_gen(yield_nones = True):
         if event is None:
@@ -250,7 +276,7 @@ def main(args, logger):
             instance_dir = os.path.join(path, filename)
             if os.path.isdir(instance_dir):
                 # Instance added
-                i.add_watch(instance_dir, mask=mask)
+                _try_add_watch(i, instance_dir, mask, logger)
                 _timeout = args.timeout + (random.random() * 5) - 2.5  # spread polling intervals
                 dirs[instance_dir] = InstanceDir(instance_dir, _timeout, logger)
             elif instance_dir in dirs:


### PR DESCRIPTION
## Summary

A collection of frontend improvements developed and tested on our local branch.
The commits are organised to be reviewed individually or adopted selectively.

### Infrastructure

- **docker_run: add `run_user` param** — lets callers specify uid:gid so containers run as non-root without hardcoding it in images.
- **docker_compose_service: Ubuntu 26.04+ uses docker compose v2 plugin** — detects Ubuntu 26.04+ and selects the compose2 systemd service template accordingly.

### Frontend networking / startup

- **configure-container-network: nftables-aware veth setup; docker compose v2 container naming** — handles both old (`instance_haproxy_1`) and new (`instance-haproxy-1`) compose v2 container naming; replaces the old bridge-based veth setup with a version that works under nftables (moves the veth into the docker network namespace where applicable, sets up source-routing for anycasted addresses).
- **start-frontend: fix zombie children after execv; support docker compose v2 plugin** — replaces `multiprocessing.Queue` with a pipe + double-fork so the intermediate child exits before the parent `execv`s into docker-compose (avoiding zombies); adds `--compose_bin /usr/bin/docker` support for the v2 plugin.

### Health-based VIP routing

- **frontend: health-based VIP routing via frontend-route-adjust** — replaces the old Python monitor script with a two-part design:
  - `exabgp_monitor` (bash): creates a FIFO, pushes initial route state, then relays ongoing updates from the FIFO to exabgp stdout.
  - `frontend-route-adjust@<instance>` (systemd path+service): watches the per-instance `announce` file written by the health-check container; on change, pushes route add/withdraw commands into the FIFO and manages kernel routes on `to_<instance>`.
  - `frontend-route-adjust-stop@<instance>` (oneshot): withdraws all routes cleanly on frontend stop.
  - exabgp and its FIFO dir (`/var/run/frontend-exabgp`) run as a dedicated non-root `exabgp` user; a `tmpfiles.d` entry recreates the dir on boot.

### API

- **frontend/api: allow_clients param, configurable port, run_user** — `api/server` gains `allow_clients` (nftables DNAT rule via `sunet::nftables::docker_expose`), a configurable `port` (default 8080), and `run_user` for non-root execution. `api/instance` gets a configurable `group` for the backends directory so the API container can write to it.

### Bug fixes / compatibility

- **frontend/docker-compose_template: haproxy_control path, HOSTFQDN Puppet 8 fix, STATSSOCKET env** — corrects the haproxy control socket path to `/haproxy_control`; fixes `HOSTFQDN` to use `$facts['networking']['fqdn']` (the `@fqdn` variable is not available in Puppet 8 templates); adds `STATSSOCKET` env var.
- **frontend: nftables, docker0-absent, Puppet 8 compat fixes** — `peer`: guard `is_ipaddr()` against undef `local_ip`; `load_balancer`/`website2`: use `facts.dig()` for `docker0` IP so nftables hosts (no docker0) don't crash; `website2`: replace unconditional `ufw route` exec with a conditional nftables conf.d rule.
- **websites2_monitor: poll-only fallback when inotify unavailable** — kernel 5.15.0-1100 returns ERRNO=0 from `inotify_add_watch`; catch `InotifyError` and fall back to a pure polling loop.