### PR TITLE
fix apt get update hanging issue

### DIFF
--- a/templates/updater/silent-update-and-upgrade.erb
+++ b/templates/updater/silent-update-and-upgrade.erb
@@ -3,6 +3,12 @@
 # Script created by Puppet (sunet::updater)
 #
 
+# ---------- NOTE ----------
+# Due to a bug in apt's scheduler, we run apt-get with timeout
+# to avoid it from hanging forever.
+# This fix is only needed for apt versions before 3.1.3
+# ---------- END NOTE ----------
+
 export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 # Max time to allow a single apt-get upgrade attempt to run before

--- a/templates/updater/silent-update-and-upgrade.erb
+++ b/templates/updater/silent-update-and-upgrade.erb
@@ -31,10 +31,10 @@ handle_error() {
     if [[ $1 -eq 0 ]]; then return; fi
 
     if [[ $1 -ge 124 ]]; then
-        logger -p local0.err -i -t silent-update-and-upgrade "apt-get hung and was killed (exit ${rc}), recovering"
+        logger -p local0.err -i -t silent-update-and-upgrade "apt-get hung and was killed (exit ${1}), recovering"
         recover_apt_state
     else
-        logger -p local0.err -i -t silent-update-and-upgrade "apt failed (exit ${rc})"
+        logger -p local0.err -i -t silent-update-and-upgrade "apt failed (exit ${1})"
     fi
 }
 

--- a/templates/updater/silent-update-and-upgrade.erb
+++ b/templates/updater/silent-update-and-upgrade.erb
@@ -5,16 +5,63 @@
 
 export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
+# Max time to allow a single apt-get upgrade attempt to run before
+# we assume it's hung (e.g. due to the scheduler bug) and kill it.
+APT_TIMEOUT=1800    # 30 minutes
+APT_KILL_AFTER=60   # grace period between SIGTERM and SIGKILL
+
+RANDOM_SLEEP=0
 if [[ "$1" == "--random-sleep" ]]; then
+    RANDOM_SLEEP=1
     sleep $(( $RANDOM % 120))
 fi
 
+# Recover from a previous hung/killed apt run: clear stale locks and
+# finish any half-configured packages before we try anything new.
+recover_apt_state() {
+    logger -p local0.warning -i -t silent-update-and-upgrade "Recovering apt/dpkg state before upgrade attempt"
+    rm -f /var/lib/apt/lists/lock \
+          /var/cache/apt/archives/lock \
+          /var/lib/dpkg/lock \
+          /var/lib/dpkg/lock-frontend
+    dpkg --configure -a || true
+}
+
+handle_error() {
+    if [[ $1 -eq 0 ]]; then return; fi
+
+    if [[ $1 -ge 124 ]]; then
+        logger -p local0.err -i -t silent-update-and-upgrade "apt-get hung and was killed (exit ${rc}), recovering"
+        recover_apt_state
+    else
+        logger -p local0.err -i -t silent-update-and-upgrade "apt failed (exit ${rc})"
+    fi
+}
+
+run_upgrade() {
+    local qq_flag=()
+    [[ -n "$1" ]] && qq_flag=("$1")
+
+    if [[ "$RANDOM_SLEEP" == "1" ]]; then
+        timeout --kill-after="${APT_KILL_AFTER}" "${APT_TIMEOUT}" \
+            apt-get "${qq_flag[@]}" -y update \
+        && timeout --kill-after="${APT_KILL_AFTER}" "${APT_TIMEOUT}" \
+            env DEBIAN_FRONTEND='noninteractive' apt-get "${qq_flag[@]}" -y \
+            -o Dpkg::Options::='--force-confnew' upgrade
+    else
+        apt-get "${qq_flag[@]}" -y update \
+        && env DEBIAN_FRONTEND='noninteractive' apt-get "${qq_flag[@]}" -y \
+            -o Dpkg::Options::='--force-confnew' upgrade
+    fi
+}
+
 status=1
-apt-get -y update && env DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confnew' upgrade && status=0
-if [[ $status != 0 && "$1" == "--random-sleep" ]]; then
-    echo ": apt failed, sleeping for 10 minutes before retrying"
-    sleep 600
-    apt-get -qq -y update && env DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confnew' upgrade && status=0
+run_upgrade "" && status=0
+handle_error $?
+
+if [[ "$1" == "--random-sleep" ]]; then
+    run_upgrade "-qq" && status=0
+    handle_error $?
 fi
 
 if [[ -f /var/run/reboot-required && -f /etc/cosmos-automatic-reboot ]]; then
@@ -23,8 +70,8 @@ if [[ -f /var/run/reboot-required && -f /etc/cosmos-automatic-reboot ]]; then
     logger -p local0.emerg -i -t silent-update-and-upgrade "Rebooting automatically in ${sleep} seconds (if /var/run/reboot-required still exists)"
     sleep $sleep
     if [ -f /var/run/reboot-required ]; then
-	logger -p local0.crit -i -t silent-update-and-upgrade "Rebooting automatically"
-	reboot
+        logger -p local0.crit -i -t silent-update-and-upgrade "Rebooting automatically"
+        reboot
     fi
 fi
 


### PR DESCRIPTION
Fix an [issue](https://bugs.launchpad.net/ubuntu/+source/apt/+bug/2003851) where apt-get hangs indefinitely under certain conditions. This fix is for servers which are running a version of apt older than [3.1.3](https://launchpad.net/ubuntu/+source/apt/3.1.3)
