### PR TITLE
Mikand edusign max file size

### DIFF
--- a/manifests/edusign/app.pp
+++ b/manifests/edusign/app.pp
@@ -37,7 +37,6 @@ class sunet::edusign::app(
             "SP_HOSTNAME=${_host}",
             'BACKEND_HOST=edusign-app.docker',
             'ACMEPROXY=acme-c.sunet.se',
-            'DISCO_URL=https://service.seamlessaccess.org/ds/?trustProfile=edugain',
             "MULTISIGN_BUTTONS=${invites}",
             'MDQ_BASE_URL=https://mds.swamid.se/',
             'MDQ_SIGNER_CERT=/etc/shibboleth/md-signer2.crt'

--- a/manifests/edusign/app.pp
+++ b/manifests/edusign/app.pp
@@ -37,6 +37,7 @@ class sunet::edusign::app(
             "SP_HOSTNAME=${_host}",
             'BACKEND_HOST=edusign-app.docker',
             'ACMEPROXY=acme-c.sunet.se',
+            'DISCO_URL=https://service.seamlessaccess.org/ds/?trustProfile=edugain',
             "MULTISIGN_BUTTONS=${invites}",
             'MDQ_BASE_URL=https://mds.swamid.se/',
             'MDQ_SIGNER_CERT=/etc/shibboleth/md-signer2.crt'

--- a/manifests/edusign/app.pp
+++ b/manifests/edusign/app.pp
@@ -32,7 +32,7 @@ class sunet::edusign::app(
   $edusign_idp_entityid = hiera('edusign_idp_entityid', '')
   $edusign_metadata_file = hiera('edusign_metadata_file', '')
   $edusign_sp_extra_variables = hiera('edusign_sp_extra_variables', [])
-  
+
   $env_sp = ['METADATA_FILE=/etc/metadata/swamid-idp-transitive.xml',
             "SP_HOSTNAME=${_host}",
             'BACKEND_HOST=edusign-app.docker',

--- a/manifests/edusign/app.pp
+++ b/manifests/edusign/app.pp
@@ -31,16 +31,18 @@ class sunet::edusign::app(
 
   $edusign_idp_entityid = hiera('edusign_idp_entityid', '')
   $edusign_metadata_file = hiera('edusign_metadata_file', '')
+  $edusign_sp_extra_variables = hiera('edusign_sp_extra_variables', [])
   $env_sp = ['METADATA_FILE=/etc/metadata/swamid-idp-transitive.xml',
             "SP_HOSTNAME=${_host}",
             'BACKEND_HOST=edusign-app.docker',
-            'MAX_FILE_SIZE=20M',
             'ACMEPROXY=acme-c.sunet.se',
             'DISCO_URL=https://service.seamlessaccess.org/ds/?trustProfile=edugain',
             "MULTISIGN_BUTTONS=${invites}",
             'MDQ_BASE_URL=https://mds.swamid.se/',
             'MDQ_SIGNER_CERT=/etc/shibboleth/md-signer2.crt'
             ]
+            
+  $env_sp_final = $env_sp + $edusign_sp_extra_variables
 
   if ($edusign_idp_entityid == '') {
     sunet::docker_run{'edusign-sp':

--- a/manifests/edusign/app.pp
+++ b/manifests/edusign/app.pp
@@ -32,6 +32,7 @@ class sunet::edusign::app(
   $edusign_idp_entityid = hiera('edusign_idp_entityid', '')
   $edusign_metadata_file = hiera('edusign_metadata_file', '')
   $edusign_sp_extra_variables = hiera('edusign_sp_extra_variables', [])
+  
   $env_sp = ['METADATA_FILE=/etc/metadata/swamid-idp-transitive.xml',
             "SP_HOSTNAME=${_host}",
             'BACKEND_HOST=edusign-app.docker',
@@ -41,7 +42,7 @@ class sunet::edusign::app(
             'MDQ_BASE_URL=https://mds.swamid.se/',
             'MDQ_SIGNER_CERT=/etc/shibboleth/md-signer2.crt'
             ]
-            
+
   $env_sp_final = $env_sp + $edusign_sp_extra_variables
 
   if ($edusign_idp_entityid == '') {


### PR DESCRIPTION
Fix in order for Edusign to support 20MB file uploads as advertised. Prior i could only upload max 15MB. now 21MB.
Related customer issue: https://jira.sunet.se/projects/EDUSIGN/queues/custom/500/EDUSIGN-388
The changes has been validated and tested. 

This change will allow us to set the values dynamically as opposed to being hardcoded.
These changes are also aligned with the upcoming implementations for BankID and FREJA.

edusign_sp_extra_variables:
    - "MAX_FILE_SIZE=30M"

edusign_app_extra_variables:
    - "MAX_FILE_SIZE=30000000"
    - "MAX_FILE_SIZE_FRONT=30000000"