### PR TITLE
Disable downloading of repository bundles

### DIFF
--- a/templates/forgejo/app.ini.erb
+++ b/templates/forgejo/app.ini.erb
@@ -44,6 +44,8 @@ ENABLE_FEDERATED_AVATAR = false
 ROOT = /opt/forgejo/data/forgejo-repositories
 DEFAULT_BRANCH = main
 MAX_CREATION_LIMIT = -1
+ENABLE_ARCHIVE = false
+DISABLE_DOWNLOAD_SOURCE_ARCHIVES = true
 
 [service]
 DISABLE_REGISTRATION = false


### PR DESCRIPTION
Most LLMs seem to respect robots.txt, but from time to time an agent will download all tags of all repositories all formats offered.  These files are cached on the server and can use up hundreds of gigabytes of storage overnight until the server crashes.