### PR TITLE
Don't expose all acmed certificate in certbot::sync

### DIFF
--- a/files/certbot-sync/certbot-sync-export.sh
+++ b/files/certbot-sync/certbot-sync-export.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# certbot deploy hook, installed by sunet::certbot::sync::server.
+#
+# certbot runs this per renewed lineage with RENEWED_LINEAGE set. If the cert's
+# domain is opted in as exportable in /etc/letsencrypt/acmedns.json, install the
+# (dereferenced) cert files into /opt/certbot-sync/export/live/<name> for sync
+# clients to fetch. Certs not marked exportable are kept out of (and removed
+# from) the export dir.
+
+set -eu
+
+exportdir="/opt/certbot-sync/export"
+acmedns="/etc/letsencrypt/acmedns.json"
+
+lineage="${RENEWED_LINEAGE:-}"
+if [[ -z "${lineage}" ]]; then
+	echo "RENEWED_LINEAGE is not set - this script must be run as a certbot deploy hook."
+	exit 1
+fi
+name="$(basename "${lineage}")"
+
+# RENEWED_DOMAINS is a space separated list; also match SAN certs whose lineage
+# name differs from the acmedns.json key.
+read -r -a renewed_domains <<<"${RENEWED_DOMAINS:-}"
+
+exportable="no"
+for key in "${name}" "${renewed_domains[@]}"; do
+	[[ -z "${key}" ]] && continue
+	if jq -e --arg k "${key}" '(.[$k].exportable // false) == true' "${acmedns}" >/dev/null 2>&1; then
+		exportable="yes"
+		break
+	fi
+done
+
+dest="${exportdir}/live/${name}"
+
+if [[ "${exportable}" != "yes" ]]; then
+	echo "${name} is not marked exportable in ${acmedns}; ensuring it is not exported."
+	rm -rf "${dest}"
+	exit 0
+fi
+
+install -d -m 0700 "${exportdir}"
+install -d -m 0700 "${exportdir}/live"
+install -d -m 0700 "${dest}"
+
+# install(1) follows the live/ -> archive/ symlinks and writes a real regular
+# file at the destination, so clients receive plain files rather than symlinks.
+# fullchain.pem is written last since clients key their "changed?" check off it.
+for f in privkey cert chain fullchain; do
+	install -m 0600 "${lineage}/${f}.pem" "${dest}/${f}.pem"
+done
+
+echo "Exported ${name} to ${dest}."

--- a/files/certbot-sync/certbot-sync-from-server.sh
+++ b/files/certbot-sync/certbot-sync-from-server.sh
@@ -8,7 +8,7 @@ hookdir="$basedir/renewal-hooks/deploy"
 
 config=${basedir}/conf/certbot-sync-from-server.source
 if [[ -f "${config}" ]]; then
-  # shellcheck source=/dev/null
+	# shellcheck source=/dev/null
 	. ${config}
 else
 	echo "No config (${config}) found!"
@@ -26,11 +26,17 @@ else
 	targetdir=$(mktemp -d /tmp/certbot_sync.XXXXX)
 fi
 
+# Only ever sync the live/ tree out of the export dir.
+mkdir -p "${targetdir}/live"
 if [[ "${CERTBOT_SYNC_SERVER}" = "$(hostname -f)" ]]; then
-	rsync -az -v /etc/letsencrypt/ "${targetdir}"
+	rsync -az -v /opt/certbot-sync/export/live/ "${targetdir}/live/"
 else
-	rsync -e "ssh -i $HOME/.ssh/id_certbot_sync_client" -az -v root@"${CERTBOT_SYNC_SERVER}": "${targetdir}"
+	rsync -e "ssh -i $HOME/.ssh/id_certbot_sync_client" -az -v root@"${CERTBOT_SYNC_SERVER}":live/ "${targetdir}/live/"
 fi
+
+# With default-closed exporting the live/ dir can be empty; don't let the glob
+# expand to itself and produce a bogus "*" cert. Also covers the hook loop below.
+shopt -s nullglob
 
 certs_to_deploy=()
 for file_system_entity in "${targetdir}"/live/*; do
@@ -61,9 +67,7 @@ if [[ "${bootstrap}" == 0 ]]; then
 	rm -vrf "${targetdir}"
 fi
 
-# Don't expand the glob to itself if no matching hooks
-# Not all services do need hooks
-shopt -s nullglob
+# Not all services need hooks; nullglob (set above) keeps this loop empty then.
 for cert in "${certs_to_deploy[@]}"; do
 	for hook in "$hookdir"/*; do
 		echo "Running deploy hook ${hook} for ${cert}."

--- a/manifests/certbot/sync/server.pp
+++ b/manifests/certbot/sync/server.pp
@@ -66,8 +66,7 @@ class sunet::certbot::sync::server(
 
   # certbot deploy hook: on each renewal, export the cert iff its domain is
   # marked exportable in acmedns.json.
-  ensure_resource('file', '/etc/letsencrypt/renewal-hooks', { ensure => directory })
-  ensure_resource('file', '/etc/letsencrypt/renewal-hooks/deploy', { ensure => directory })
+  include sunet::packages::certbot
   file { '/etc/letsencrypt/renewal-hooks/deploy/certbot-sync-export':
     ensure  => file,
     mode    => '0700',

--- a/manifests/certbot/sync/server.pp
+++ b/manifests/certbot/sync/server.pp
@@ -71,5 +71,6 @@ class sunet::certbot::sync::server(
     ensure  => file,
     mode    => '0700',
     content => file('sunet/certbot-sync/certbot-sync-export.sh'),
+    before  => Class['sunet::certbot::acmed']
   }
 }

--- a/manifests/certbot/sync/server.pp
+++ b/manifests/certbot/sync/server.pp
@@ -64,7 +64,7 @@ class sunet::certbot::sync::server(
     group  => 'root',
   }
 
-  # certbot deploy hook: on each renewal, export the cert iff its domain is
+  # certbot deploy hook: on each renewal, export the cert if its domain is
   # marked exportable in acmedns.json.
   include sunet::packages::certbot
   file { '/etc/letsencrypt/renewal-hooks/deploy/certbot-sync-export':

--- a/manifests/certbot/sync/server.pp
+++ b/manifests/certbot/sync/server.pp
@@ -1,6 +1,15 @@
 # the certbot sync server
 class sunet::certbot::sync::server(
 ){
+  # rrsync jail exposed to sync clients. Populated by the certbot deploy hook
+  # below, which installs only the certs whose domain is marked exportable in
+  # /etc/letsencrypt/acmedns.json. rrsync can only jail a directory, it cannot
+  # filter within one, so the filtering lives in what the hook copies here.
+  $jail = '/opt/certbot-sync/export'
+
+  # The deploy hook parses acmedns.json with jq.
+  include sunet::packages::jq
+
   $client_ips = lookup('certbot_sync_client_ips', undef, undef, [])
   $client_ips.each |$ip| {
     sunet::nftables::allow { "certbot_sync_client_${ip}":
@@ -8,8 +17,60 @@ class sunet::certbot::sync::server(
       port => 22,
     }
   }
+
+  # The server owns the rrsync forced command so it always jails clients to the
+  # export dir. We take the raw key material from the key database and inject our
+  # own options, ignoring any command that may be set there.
+  $forced_command = "/usr/bin/rrsync -ro ${jail}"
+  $forced_options = join([
+    "command=\"${forced_command}\"",
+    'no-agent-forwarding',
+    'no-port-forwarding',
+    'no-pty',
+    'no-user-rc',
+    'no-X11-forwarding',
+  ], ',')
+
+  $raw_keydb = safe_hiera('certbot_sync_client_ssh_keys_db', {})
+  $sync_keydb = Hash($raw_keydb.map |$keyname, $keydata| {
+    [$keyname, {
+      'key'     => $keydata['key'],
+      'type'    => pick($keydata['type'], 'ssh-rsa'),
+      'name'    => pick($keydata['name'], $keyname),
+      'options' => $forced_options,
+    }]
+  })
+
   sunet::ssh_keys { 'sync_client-keys':
-    config            => safe_hiera('certbot_sync_client_ssh_keys_mapping', {}),
-    key_database_name => 'certbot_sync_client_ssh_keys_db'
+    config   => safe_hiera('certbot_sync_client_ssh_keys_mapping', {}),
+    database => $sync_keydb,
+  }
+
+  # The export dir clients rsync from. Contents are managed by the deploy hook,
+  # so we only manage the dirs themselves (no recurse/purge).
+  ensure_resource('file', '/opt/certbot-sync', {
+    ensure => directory, mode => '0700', owner => 'root', group => 'root',
+  })
+  file { '/opt/certbot-sync/export':
+    ensure => directory,
+    mode   => '0700',
+    owner  => 'root',
+    group  => 'root',
+  }
+  file { '/opt/certbot-sync/export/live':
+    ensure => directory,
+    mode   => '0700',
+    owner  => 'root',
+    group  => 'root',
+  }
+
+  # certbot deploy hook: on each renewal, export the cert iff its domain is
+  # marked exportable in acmedns.json.
+  ensure_resource('file', '/etc/letsencrypt/renewal-hooks', { ensure => directory })
+  ensure_resource('file', '/etc/letsencrypt/renewal-hooks/deploy', { ensure => directory })
+  file { '/etc/letsencrypt/renewal-hooks/deploy/certbot-sync-export':
+    ensure  => file,
+    mode    => '0700',
+    content => file('sunet/certbot-sync/certbot-sync-export.sh'),
   }
 }

--- a/manifests/packages/certbot.pp
+++ b/manifests/packages/certbot.pp
@@ -1,4 +1,12 @@
 # certbot
 class sunet::packages::certbot {
     package { 'certbot': ensure => installed }
+
+    file { [
+    '/etc/letsencrypt/renewal-hooks',
+    '/etc/letsencrypt/renewal-hooks/deploy',
+    ]:
+      ensure  => directory,
+      require => Package['certbot'],
+    }
 }


### PR DESCRIPTION
And also make sure that the directory for hooks are always available for other classes to put files in