### PR TITLE
added dig function in redis.pp to handle missing interface keys

### DIFF
--- a/manifests/redis/server.pp
+++ b/manifests/redis/server.pp
@@ -23,11 +23,15 @@ define sunet::redis::server(
   }
 
   # Configure all nodes as slaveof $master_ip, unless this node actually has $master_ip on eth0/bond0
+  # Use dig() so a missing interface (e.g. no bond0) yields undef instead of raising
+  # "Operator '[]' is not applicable to an Undef Value" from deep-indexing a structured fact.
+  $eth0_ip  = $facts.dig('networking', 'interfaces', 'eth0', 'ip')
+  $bond0_ip = $facts.dig('networking', 'interfaces', 'bond0', 'ip')
   $slave_node = $master_ip ? {
-    $facts['networking']['interfaces']['eth0']['ip']    => 'no',
-    $facts['networking']['interfaces']['bond0']['ip']   => 'no',
+    $eth0_ip                   => 'no',
+    $bond0_ip                  => 'no',
     $facts['networking']['ip'] => 'no',
-    default              => 'yes',
+    default                    => 'yes',
   }
 
   if $slave_node == 'yes' {


### PR DESCRIPTION
## Background

Node `db-dcoa-1.eduid.se` failed to compile its catalog with:

Error: Evaluation Error: Operator '[]' is not applicable to an Undef Value.
(file: manifests/redis/server.pp, line: 28, column: 5)

**Root cause:** commit `a89f94f6` *"Fix legacy facts"* replaced legacy top-scope facts
(`$::ipaddress_bond0`) with structured facts
(`$facts['networking']['interfaces']['bond0']['ip']`). Legacy facts degrade to `undef`
harmlessly; deep-indexing a structured fact is **not** undef-safe — if an intermediate key
(`bond0`) is missing, the trailing `['ip']` raises the error above.

`db-dcoa-1` has no `bond0` interface, so the lookup crashed. **Fixed** in `redis/server.pp`
using `$facts.dig(...)`.

## Other instances of the same pattern

A grep for interface-specific deep-indexing (`$facts['networking']['interfaces']['<if>']['ip']`)
found the following latent bugs. `$facts['os'][...]` lookups and
`has_key($facts['networking']['interfaces'], ...)` checks are **safe** and excluded.

| # | Location | Code | Risk |
|---|----------|------|------|
| 1 | `manifests/frontend/load_balancer/website2.pp:110` | `pick($facts['networking']['interfaces']['docker0']['ip'], $facts['networking']['ip'])` | **High** — `pick` fallback defeated; arg crashes before `pick` runs if `docker0` is missing |
| 2 | `manifests/frontend/load_balancer.pp:80` | `pick($facts['networking']['interfaces']['docker0']['ip'], 'no-address-provided')` | **High** — same `pick`-masked crash |
| 3 | `manifests/frontend/load_balancer/website.pp:68` | `$_docker_ip = $facts['networking']['interfaces']['docker0']['ip']` | **Medium** — only guarded by `sunet_nftables_enabled != 'yes'`, not by `docker0` existence |
| 4 | `manifests/lb/load_balancer/website.pp:69` | `$_docker_ip = $facts['networking']['interfaces']['docker0']['ip']` | **Medium** — identical to #3 |
| 5 | `manifests/bird.pp:13` | `undef => $facts['networking']['interfaces']['eth0']['ip']` | **Low** — only reached if `$router_id` is undef (defaults to `networking.ip`), then crashes if no `eth0` |

> **Note on #1 and #2:** the `pick(...)` was meant to provide a fallback, but the crash occurs
> during argument evaluation, so the fallback never protects anything. These fail on any host
> without a `docker0` interface (fresh install before Docker starts, or non-Docker hosts).

## Fix

Replace deep-indexing with `dig()`, which returns `undef` cleanly on a missing interface.

**Redis (applied):**

```puppet
$eth0_ip  = $facts.dig('networking', 'interfaces', 'eth0', 'ip')
$bond0_ip = $facts.dig('networking', 'interfaces', 'bond0', 'ip')

$slave_node = $master_ip ? {
  $eth0_ip                   => 'no',
  $bond0_ip                  => 'no',
  $facts['networking']['ip'] => 'no',
  default                    => 'yes',
}

pick cases (#1, #2):

$statsd_host = pick($facts.dig('networking', 'interfaces', 'docker0', 'ip'), $facts['networking']['ip'])

Direct-assignment cases (#3, #4, #5):

$_docker_ip = $facts.dig('networking', 'interfaces', 'docker0', 'ip')