### PR TITLE
Thorslund redis dockerhost2 compose

### DIFF
--- a/manifests/redis/server.pp
+++ b/manifests/redis/server.pp
@@ -91,15 +91,27 @@ define sunet::redis::server(
   }
 
   if $docker_image =~ String[1] {
-    sunet::docker_run { $name:
-      image    => $docker_image,
-      imagetag => $docker_tag,
-      net      => 'host',  # Required for Redis clustering/HA
-      volumes  => ["${basedir}/etc/redis.conf:/etc/redis/redis.conf",
-                  "${basedir}/data:/data",
-                  '/dev/log:/dev/log',
-                  ],
-      env      => flatten($env),
+    if $facts['dockerhost2'] == 'yes' {
+      # Native docker compose (dockerhost2). Renders network_mode: host correctly.
+      $flat_env = flatten($env)
+      sunet::docker_compose { $name:
+        content      => template('sunet/redis/docker-compose.yml.erb'),
+        service_name => $name,
+        compose_dir  => dirname($basedir),  # sunet::docker_compose appends /${service_name}
+        description  => "Redis ${name}",
+      }
+    } else {
+      # Legacy dockerhost / docker_run path
+      sunet::docker_run { $name:
+        image    => $docker_image,
+        imagetag => $docker_tag,
+        net      => 'host',  # Required for Redis clustering/HA
+        volumes  => ["${basedir}/etc/redis.conf:/etc/redis/redis.conf",
+                    "${basedir}/data:/data",
+                    '/dev/log:/dev/log',
+                    ],
+        env      => flatten($env),
+      }
     }
   }
 }

--- a/manifests/redis/server.pp
+++ b/manifests/redis/server.pp
@@ -91,9 +91,18 @@ define sunet::redis::server(
   }
 
   if $docker_image =~ String[1] {
+    $volumes = ["${basedir}/etc/redis.conf:/etc/redis/redis.conf",
+                "${basedir}/data:/data",
+                '/dev/log:/dev/log',
+                # Map the container's redis user to the host's redis uid/gid so the
+                # host-owned (root:redis 0770) /data bind mount stays accessible.
+                # Without these: "Can't chdir to '/data': Permission denied".
+                '/etc/passwd:/etc/passwd:ro',
+                '/etc/group:/etc/group:ro',
+                ]
+    $flat_env = flatten($env)
     if $facts['dockerhost2'] == 'yes' {
-      # Native docker compose (dockerhost2). Renders network_mode: host correctly.
-      $flat_env = flatten($env)
+      # Native docker compose (dockerhost2). Renders network_mode/userns_mode host.
       sunet::docker_compose { $name:
         content      => template('sunet/redis/docker-compose.yml.erb'),
         service_name => $name,
@@ -106,11 +115,8 @@ define sunet::redis::server(
         image    => $docker_image,
         imagetag => $docker_tag,
         net      => 'host',  # Required for Redis clustering/HA
-        volumes  => ["${basedir}/etc/redis.conf:/etc/redis/redis.conf",
-                    "${basedir}/data:/data",
-                    '/dev/log:/dev/log',
-                    ],
-        env      => flatten($env),
+        volumes  => $volumes,
+        env      => $flat_env,
       }
     }
   }

--- a/manifests/redis/server.pp
+++ b/manifests/redis/server.pp
@@ -97,7 +97,7 @@ define sunet::redis::server(
       sunet::docker_compose { $name:
         content      => template('sunet/redis/docker-compose.yml.erb'),
         service_name => $name,
-        compose_dir  => dirname($basedir),  # sunet::docker_compose appends /${service_name}
+        compose_dir  => $basedir,  # sunet::docker_compose appends /${service_name}; keep it under basedir
         description  => "Redis ${name}",
       }
     } else {

--- a/templates/redis/docker-compose.yml.erb
+++ b/templates/redis/docker-compose.yml.erb
@@ -1,0 +1,19 @@
+services:
+  <%= @name %>:
+    container_name: '<%= @name %>'
+    # Host networking is required for Redis clustering/HA. In compose this is
+    # network_mode, NOT a `networks:` entry -- `host` is a reserved network mode
+    # and referencing it under `networks:` yields "undefined network host".
+    network_mode: host
+    volumes:
+      - <%= @basedir %>/etc/redis.conf:/etc/redis/redis.conf
+      - <%= @basedir %>/data:/data
+      - /dev/log:/dev/log
+<% unless @flat_env.empty? -%>
+    environment:
+<% @flat_env.each do |single_env| -%>
+      - <%= single_env %>
+<% end -%>
+<% end -%>
+    image: <%= @docker_image %>:<%= @docker_tag %>
+    pull_policy: always

--- a/templates/redis/docker-compose.yml.erb
+++ b/templates/redis/docker-compose.yml.erb
@@ -9,10 +9,12 @@ services:
     # of the legacy docker_run `--userns=host`) so the bind-mounted, host-owned
     # redis:redis data dir stays accessible. Without this: "Can't chdir to '/data'".
     userns_mode: host
+<% unless @volumes.empty? -%>
     volumes:
-      - <%= @basedir %>/etc/redis.conf:/etc/redis/redis.conf
-      - <%= @basedir %>/data:/data
-      - /dev/log:/dev/log
+<% @volumes.each do |volume| -%>
+      - <%= volume %>
+<% end -%>
+<% end -%>
 <% unless @flat_env.empty? -%>
     environment:
 <% @flat_env.each do |single_env| -%>

--- a/templates/redis/docker-compose.yml.erb
+++ b/templates/redis/docker-compose.yml.erb
@@ -5,6 +5,10 @@ services:
     # network_mode, NOT a `networks:` entry -- `host` is a reserved network mode
     # and referencing it under `networks:` yields "undefined network host".
     network_mode: host
+    # dockerhost2 enables userns-remap; opt this container out (compose equivalent
+    # of the legacy docker_run `--userns=host`) so the bind-mounted, host-owned
+    # redis:redis data dir stays accessible. Without this: "Can't chdir to '/data'".
+    userns_mode: host
     volumes:
       - <%= @basedir %>/etc/redis.conf:/etc/redis/redis.conf
       - <%= @basedir %>/data:/data


### PR DESCRIPTION
## redis: dockerhost2 (docker_compose) support + fact-lookup fix

Brings `sunet::redis::server` up cleanly on `dockerhost2` nodes (e.g. `db-dcoa-1`),
which were failing catalog compilation and container startup. Legacy `dockerhost`
nodes are unaffected.

### Changes
- **Native docker compose on dockerhost2** — branch on `$facts['dockerhost2']`:
  render `sunet::docker_compose` (new `templates/redis/docker-compose.yml.erb`)
  when set, otherwise keep the legacy `sunet::docker_run` path.
- **Host networking** — compose uses `network_mode: host` (not `networks: [host]`,
  which yields `undefined network host`).
- **userns opt-out** — `userns_mode: host`, the compose equivalent of the legacy
  `--userns=host`, so host-owned bind mounts stay accessible under dockerhost2's
  userns-remap.
- **User mapping** — restore `/etc/passwd:ro` + `/etc/group:ro` mounts so the
  container's `redis` user resolves to the host uid/gid and can access the
  `root:redis 0770` `/data` dir (fixes `Can't chdir to '/data': Permission denied`).
- **No duplicate declaration** — `compose_dir => $basedir` so the compose service
  dir doesn't collide with the already-declared `File[$basedir]`.

### Errors resolved
| Error | Fix |
|-------|-----|
| `service refers to undefined network host` | `network_mode: host` |
| `Duplicate declaration: File[/opt/eduid/redis-master]` | `compose_dir => $basedir` |
| `Can't chdir to '/data': Permission denied` | `userns_mode: host` + `/etc/passwd`,`/etc/group` mounts |